### PR TITLE
Integrate mj_environment for planning state management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,21 @@ dependencies = [
     "mujoco",
     "pyyaml",
     "toppra>=0.6.3",
+    "mj_environment @ git+https://github.com/personalrobotics/mj_environment.git",
+    "geodude-assets",
 ]
+
+[tool.uv.sources]
+geodude-assets = { path = "../geodude_assets", editable = true }
 
 [project.optional-dependencies]
 dev = [
     "pytest",
     "ruff",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/geodude"]

--- a/src/geodude/arm.py
+++ b/src/geodude/arm.py
@@ -637,6 +637,9 @@ class Arm:
                 "Or: uv add pycbirrt[eaik]"
             )
 
+        # Create fork to preserve state (planning corrupts self.data)
+        state_snapshot = self.robot.env.fork()
+
         q_start = self.get_joint_positions()
 
         config = CBiRRTConfig(
@@ -653,13 +656,10 @@ class Arm:
             path = planner.plan(start=q_start, goal=q_goal, seed=seed)
         except ValueError:
             # Invalid goal configuration (collision or constraint violation)
-            return None
-
-        # CRITICAL: Restore robot state after planning
-        # Planner corrupts state during collision checking and exploration
-        self.set_joint_positions(q_start)
-        for i in range(len(self.data.qvel)):
-            self.data.qvel[i] = 0.0
+            path = None
+        finally:
+            # Restore robot state from snapshot (planning corrupts state)
+            self.robot.env.sync_from(state_snapshot)
 
         return path
 
@@ -690,6 +690,9 @@ class Arm:
                 "Or: uv add pycbirrt[eaik]"
             )
 
+        # Create fork to preserve state (planning corrupts self.data)
+        state_snapshot = self.robot.env.fork()
+
         q_start = self.get_joint_positions()
 
         config = CBiRRTConfig(
@@ -712,12 +715,9 @@ class Arm:
         except ValueError:
             # No valid goal configurations found (IK failed or all in collision)
             path = None
-
-        # CRITICAL: Restore robot state after planning
-        # Planner corrupts state during collision checking and exploration
-        self.set_joint_positions(q_start)
-        for i in range(len(self.data.qvel)):
-            self.data.qvel[i] = 0.0
+        finally:
+            # Restore robot state from snapshot (planning corrupts state)
+            self.robot.env.sync_from(state_snapshot)
 
         return path
 

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import mujoco
 import numpy as np
+from mj_environment import Environment
 
 from geodude.arm import Arm
 from geodude.config import GeodudConfig
@@ -36,15 +37,20 @@ class Geodude:
         """
         self.config = config or GeodudConfig.default()
 
-        # Load MuJoCo model
+        # Load MuJoCo model via mj_environment (robot-only, no objects)
         if not self.config.model_path.exists():
             raise FileNotFoundError(
                 f"MuJoCo model not found: {self.config.model_path}\n"
                 "Make sure geodude_assets is available."
             )
 
-        self.model = mujoco.MjModel.from_xml_path(str(self.config.model_path))
-        self.data = mujoco.MjData(self.model)
+        self._env = Environment(
+            base_scene_xml=str(self.config.model_path),
+            objects_dir=None,
+            scene_config_yaml=None,
+        )
+        self.model = self._env.model
+        self.data = self._env.data
 
         # Initialize grasp manager
         self.grasp_manager = GraspManager(self.model, self.data)
@@ -115,6 +121,11 @@ class Geodude:
     def right_base(self) -> VentionBase | None:
         """Right Vention base controller (linear actuator)."""
         return self._right_base
+
+    @property
+    def env(self) -> Environment:
+        """MuJoCo environment wrapper for forking and state management."""
+        return self._env
 
     @property
     def named_poses(self) -> dict[str, dict[str, list[float]]]:

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,14 @@ wheels = [
 ]
 
 [[package]]
+name = "asset-manager"
+version = "0.1.0"
+source = { git = "https://github.com/personalrobotics/asset_manager.git#199ee7d51636d32608388055c4d36bf752d9adc4" }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -288,6 +296,8 @@ name = "geodude"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "geodude-assets" },
+    { name = "mj-environment" },
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -303,6 +313,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "geodude-assets", editable = "../geodude_assets" },
+    { name = "mj-environment", git = "https://github.com/personalrobotics/mj_environment.git" },
     { name = "mujoco" },
     { name = "numpy" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -311,6 +323,24 @@ requires-dist = [
     { name = "toppra", specifier = ">=0.6.3" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "geodude-assets"
+version = "0.1.0"
+source = { editable = "../geodude_assets" }
+dependencies = [
+    { name = "mujoco" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dm-control", marker = "extra == 'assembly'" },
+    { name = "mujoco" },
+    { name = "numpy", marker = "extra == 'assembly'" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'" },
+]
+provides-extras = ["assembly", "dev"]
 
 [[package]]
 name = "glfw"
@@ -527,6 +557,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/30/3afaa31c757f34b7725ab9d2ba8b48b5e89c2019c003e7d0ead143aabc5a/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6da7c2ce169267d0d066adcf63758f0604aa6c3eebf67458930f9d9b79ad1db1", size = 8249198, upload-time = "2025-12-10T22:56:45.584Z" },
     { url = "https://files.pythonhosted.org/packages/48/2f/6334aec331f57485a642a7c8be03cb286f29111ae71c46c38b363230063c/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9153c3292705be9f9c64498a8872118540c3f4123d1a1c840172edf262c8be4a", size = 8136817, upload-time = "2025-12-10T22:56:47.339Z" },
     { url = "https://files.pythonhosted.org/packages/73/e4/6d6f14b2a759c622f191b2d67e9075a3f56aaccb3be4bb9bb6890030d0a0/matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2", size = 8713867, upload-time = "2025-12-10T22:56:48.954Z" },
+]
+
+[[package]]
+name = "mj-environment"
+version = "0.1.0"
+source = { git = "https://github.com/personalrobotics/mj_environment.git#c07574b2ec5f651777db675ef1463cd91a3273ec" }
+dependencies = [
+    { name = "asset-manager" },
+    { name = "mujoco" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace hacky manual state save/restore with `mj_environment.Environment.fork()` and `sync_from()`
- Add `env` property to `Geodude` class for accessing the environment wrapper
- Planning methods now properly preserve all simulation state, not just qpos/qvel

## Changes

- `pyproject.toml`: Add mj_environment dependency, geodude_assets as local source
- `robot.py`: Create Environment in robot-only mode, expose via `env` property
- `arm.py`: Use `env.fork()` before planning, `env.sync_from()` after to restore state

## Test plan

- [x] Basic import and fork test passes
- [x] 99 non-planning tests pass
- [ ] Planning tests require pycbirrt (optional dependency)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)