### PR TITLE
Add comprehensive debug logging system (#43)

### DIFF
--- a/src/geodude/__init__.py
+++ b/src/geodude/__init__.py
@@ -57,6 +57,13 @@ def __getattr__(name):
     if name == "RecoveryConfig":
         from geodude.config import RecoveryConfig
         return RecoveryConfig
+    # Debug logging
+    if name == "DebugConfig":
+        from geodude.config import DebugConfig
+        return DebugConfig
+    if name == "setup_logging":
+        from geodude.config import setup_logging
+        return setup_logging
     # Execution context
     if name == "SimContext":
         from geodude.execution import SimContext
@@ -73,6 +80,8 @@ __all__ = [
     "PhysicsExecutionConfig",
     "GripperPhysicsConfig",
     "RecoveryConfig",
+    "DebugConfig",
+    "setup_logging",
     "Trajectory",
     "PlanResult",
     "SimContext",

--- a/src/geodude/config.py
+++ b/src/geodude/config.py
@@ -1,5 +1,8 @@
 """Robot configuration for Geodude."""
 
+from __future__ import annotations
+
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -329,6 +332,181 @@ class PhysicsConfig:
 
 
 @dataclass
+class DebugConfig:
+    """Debug logging configuration.
+
+    Controls which subsystems emit debug-level log messages. Uses Python's
+    logging framework with geodude.* logger hierarchy.
+
+    Subsystems:
+        - executor: Trajectory execution, convergence, physics stepping
+        - gripper: Gripper open/close, contact detection, grasp detection
+        - planning: Motion planning, collision checking, IK
+        - primitives: High-level pickup/place operations
+        - grasp_manager: Object attachment, collision group updates
+        - affordances: TSR template loading, affordance matching
+
+    Example:
+        # Enable all debug logging
+        robot.config.debug.enable_all()
+
+        # Enable specific subsystems
+        robot.config.debug.executor = True
+        robot.config.debug.gripper = True
+        robot.apply_debug_config()  # Apply changes
+
+        # Or via environment variable
+        GEODUDE_DEBUG=executor,gripper python script.py
+    """
+
+    # Per-subsystem debug flags (maps to geodude.<name> logger)
+    executor: bool = False
+    gripper: bool = False
+    planning: bool = False
+    primitives: bool = False
+    grasp_manager: bool = False
+    affordances: bool = False
+
+    # Log format settings
+    show_timestamps: bool = True
+    show_module: bool = True
+
+    def enable_all(self) -> None:
+        """Enable debug logging for all subsystems."""
+        self.executor = True
+        self.gripper = True
+        self.planning = True
+        self.primitives = True
+        self.grasp_manager = True
+        self.affordances = True
+
+    def disable_all(self) -> None:
+        """Disable debug logging for all subsystems."""
+        self.executor = False
+        self.gripper = False
+        self.planning = False
+        self.primitives = False
+        self.grasp_manager = False
+        self.affordances = False
+
+    def enable(self, *subsystems: str) -> None:
+        """Enable debug logging for specific subsystems.
+
+        Args:
+            *subsystems: Names of subsystems to enable (e.g., "executor", "gripper")
+        """
+        for name in subsystems:
+            if hasattr(self, name):
+                setattr(self, name, True)
+            else:
+                raise ValueError(f"Unknown subsystem: {name}")
+
+    def get_enabled_subsystems(self) -> list[str]:
+        """Get list of enabled subsystems."""
+        subsystems = ["executor", "gripper", "planning", "primitives",
+                      "grasp_manager", "affordances"]
+        return [s for s in subsystems if getattr(self, s)]
+
+    @classmethod
+    def from_env(cls) -> "DebugConfig":
+        """Create config from GEODUDE_DEBUG environment variable.
+
+        Format: GEODUDE_DEBUG=subsystem1,subsystem2 or GEODUDE_DEBUG=all
+        """
+        import os
+        config = cls()
+        debug_env = os.environ.get("GEODUDE_DEBUG", "")
+        if debug_env:
+            if debug_env.lower() == "all":
+                config.enable_all()
+            else:
+                subsystems = [s.strip() for s in debug_env.split(",")]
+                for s in subsystems:
+                    if s and hasattr(config, s):
+                        setattr(config, s, True)
+        return config
+
+    @classmethod
+    def default(cls) -> "DebugConfig":
+        """Default debug configuration (all disabled)."""
+        return cls()
+
+
+# Mapping from subsystem name to logger name
+_SUBSYSTEM_LOGGERS = {
+    "executor": "geodude.executor",
+    "gripper": "geodude.executor",  # Gripper is part of executor module
+    "planning": "geodude.arm",  # Planning is in arm module
+    "primitives": "geodude.primitives",
+    "grasp_manager": "geodude.grasp_manager",
+    "affordances": "geodude.affordances",
+}
+
+
+def setup_logging(config: DebugConfig | None = None) -> None:
+    """Configure geodude loggers based on debug config.
+
+    Sets up the logging hierarchy for geodude modules. By default, all
+    geodude loggers are set to WARNING level. When a subsystem is enabled
+    in DebugConfig, its logger is set to DEBUG level.
+
+    Args:
+        config: Debug configuration. If None, uses DebugConfig.from_env()
+
+    Example:
+        from geodude.config import setup_logging, DebugConfig
+
+        # From environment variable
+        setup_logging()
+
+        # Programmatic
+        config = DebugConfig()
+        config.enable("executor", "gripper")
+        setup_logging(config)
+    """
+    if config is None:
+        config = DebugConfig.from_env()
+
+    # Configure root geodude logger
+    root_logger = logging.getLogger("geodude")
+
+    # Prevent propagation to root logger (avoids duplicate output)
+    root_logger.propagate = False
+
+    # Only add handler if none exists (avoid duplicate handlers)
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+
+        # Build format string based on config
+        fmt_parts = []
+        if config.show_timestamps:
+            fmt_parts.append("%(asctime)s")
+        fmt_parts.append("%(levelname)s")
+        if config.show_module:
+            fmt_parts.append("[%(name)s]")
+        fmt_parts.append("%(message)s")
+
+        formatter = logging.Formatter(" - ".join(fmt_parts))
+        handler.setFormatter(formatter)
+        root_logger.addHandler(handler)
+
+    # Set root to WARNING by default (so DEBUG/INFO are suppressed unless enabled)
+    root_logger.setLevel(logging.WARNING)
+
+    # Enable DEBUG for specific subsystems
+    enabled = config.get_enabled_subsystems()
+    enabled_loggers = set()
+    for subsystem in enabled:
+        logger_name = _SUBSYSTEM_LOGGERS.get(subsystem)
+        if logger_name:
+            enabled_loggers.add(logger_name)
+
+    for logger_name in enabled_loggers:
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(logging.DEBUG)
+
+
+@dataclass
 class GeodudConfig:
     """Full robot configuration."""
 
@@ -339,6 +517,7 @@ class GeodudConfig:
     right_base: VentionBaseConfig | None = None
     named_poses: dict[str, dict[str, list[float]]] = field(default_factory=dict)
     physics: PhysicsConfig = field(default_factory=PhysicsConfig.default)
+    debug: DebugConfig = field(default_factory=DebugConfig.from_env)
 
     @classmethod
     def default(cls) -> "GeodudConfig":

--- a/src/geodude/executor.py
+++ b/src/geodude/executor.py
@@ -1,5 +1,6 @@
 """Trajectory execution for simulation and real robot."""
 
+import logging
 import time
 from typing import Protocol
 
@@ -7,6 +8,8 @@ import mujoco
 import numpy as np
 
 from geodude.trajectory import Trajectory
+
+logger = logging.getLogger(__name__)
 
 # Import for type hints only - avoids circular import
 from typing import TYPE_CHECKING
@@ -602,9 +605,6 @@ class RobotPhysicsController:
         Returns:
             True if converged, False if timeout
         """
-        import logging
-        logger = logging.getLogger(__name__)
-
         # Use config defaults if not specified
         if position_tolerance is None:
             position_tolerance = self.execution_config.position_tolerance
@@ -740,9 +740,6 @@ class RobotPhysicsController:
         Returns:
             Name of grasped object, or None
         """
-        import logging
-        logger = logging.getLogger(__name__)
-
         # Use config defaults
         cfg = self.gripper_config
         if steps is None:

--- a/src/geodude/grasp_manager.py
+++ b/src/geodude/grasp_manager.py
@@ -1,7 +1,11 @@
 """Grasp state management and collision group updates."""
 
+import logging
+
 import mujoco
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # Collision group bit definitions
 # Bit 0 (value 1): Normal objects and robot arm
@@ -292,9 +296,6 @@ def detect_grasped_object(
     Returns:
         Name of grasped object, or None if nothing is grasped
     """
-    import logging
-    logger = logging.getLogger(__name__)
-
     # Separate gripper bodies into left and right sides
     left_body_ids = set()
     right_body_ids = set()

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -12,7 +12,7 @@ from mj_environment import Environment
 
 from geodude.affordances import AffordanceRegistry
 from geodude.arm import Arm
-from geodude.config import GeodudConfig
+from geodude.config import GeodudConfig, setup_logging
 from geodude.grasp_manager import GraspManager
 from geodude.planning import PlanResult
 from geodude.trajectory import Trajectory
@@ -114,6 +114,9 @@ class Geodude:
         # Run forward to initialize state
         mujoco.mj_forward(self.model, self.data)
 
+        # Configure debug logging based on config (reads from env if not set)
+        setup_logging(self.config.debug)
+
     @classmethod
     def from_config(cls, config_path: str | Path) -> "Geodude":
         """Create Geodude from a YAML configuration file.
@@ -189,6 +192,21 @@ class Geodude:
     def _active_context(self, ctx: "SimContext | None") -> None:
         """Set the active execution context."""
         self._context = ctx
+
+    def apply_debug_config(self) -> None:
+        """Re-apply debug configuration to loggers.
+
+        Call this after modifying robot.config.debug to apply changes.
+
+        Example:
+            robot.config.debug.enable("executor", "gripper")
+            robot.apply_debug_config()
+        """
+        setup_logging(self.config.debug)
+
+        # Sync gripper debug flag with the debug config
+        # This allows the per-call verbose logging in close_gripper to work
+        self.config.physics.gripper.debug = self.config.debug.gripper
 
     def go_to(self, pose_name: str, speed: float = 1.0) -> bool:
         """Move both arms to a named configuration.


### PR DESCRIPTION
## Summary

Adds a structured debug logging system for easier debugging across geodude subsystems.

### New Features

**DebugConfig dataclass** with per-subsystem flags:
- `executor` - trajectory execution, convergence, physics stepping
- `gripper` - grasp detection, contact monitoring  
- `planning` - motion planning, collision checking
- `primitives` - pickup/place operations
- `grasp_manager` - object attachment
- `affordances` - TSR template loading

**Configuration methods:**
- Environment variable: `GEODUDE_DEBUG=gripper,executor` or `GEODUDE_DEBUG=all`
- Programmatic: `robot.config.debug.enable("gripper", "executor")`
- Convenience: `robot.config.debug.enable_all()`

**Integration:**
- Auto-configures on robot initialization
- `robot.apply_debug_config()` to re-apply after changes
- Uses Python's logging framework with geodude.* logger hierarchy

### Usage

```bash
# Via environment variable
GEODUDE_DEBUG=gripper,executor uv run mjpython examples/recycle.py --physics

# Or programmatically
robot.config.debug.enable("gripper", "executor")
robot.apply_debug_config()
```

### Output Example
```
2026-02-05 17:01:43,492 - DEBUG - [geodude.executor] - Gripper right: final grasp detection = None
2026-02-05 17:01:43,493 - WARNING - [geodude.primitives] - Grasp FAILED - no contact detected with can_0
```

## Files Changed

| File | Changes |
|------|---------|
| `config.py` | Add DebugConfig, setup_logging(), _SUBSYSTEM_LOGGERS mapping |
| `robot.py` | Call setup_logging on init, add apply_debug_config() method |
| `executor.py` | Use module-level logger, remove function-local logger definitions |
| `grasp_manager.py` | Add module-level logger |
| `__init__.py` | Export DebugConfig and setup_logging |

## Test plan

- [x] All 238 tests pass
- [x] `GEODUDE_DEBUG=gripper,executor` enables debug output
- [x] No duplicate log messages
- [x] Works with recycle.py --physics

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)