### PR TITLE
Raise recycle bin place TSR height and add orientation tolerance

### DIFF
--- a/tsr_templates/places/recycle_bin_drop.yaml
+++ b/tsr_templates/places/recycle_bin_drop.yaml
@@ -17,12 +17,12 @@ position:
   type: box
   x: [-0.05, 0.05]   # Centered over bin opening
   y: [-0.05, 0.05]
-  z: [0.82, 0.87]    # 2-7cm above bin top (bin top at z≈0.80)
+  z: [0.97, 1.02]    # 17-22cm above bin top (bin top at z≈0.80)
 
 orientation:
   approach: -z
-  roll: [0, 0]
-  pitch: [0, 0]
+  roll: [-10, 10]
+  pitch: [-10, 10]
   yaw: [0, 360]  # Any yaw is fine for dropping
 
 standoff: 0.0  # Position is directly above bin


### PR DESCRIPTION
## Summary
- Raise z from [0.82, 0.87] to [0.97, 1.02] (+15cm above bin rim)
- Add ±10° roll and pitch tolerance for more planning flexibility

## Motivation
The original TSR placed the gripper too close to the bin rim, causing:
- Collision risk with bin walls
- Planning failures due to tight orientation constraints

## Test plan
- [ ] Run `uv run mjpython scripts/visualize_tsr.py tsr_templates/places/recycle_bin_drop.yaml` to verify pose
- [ ] Run `uv run mjpython examples/recycle.py --physics` to verify place motion succeeds

Fixes #47