### PR TITLE
Add robot.right / robot.left arm-scoped primitives

### DIFF
--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -180,14 +180,16 @@ def place(
     return _tick_tree(geodude_place(ns), verbose=verbose)
 
 
-def go_home(robot: Geodude, *, verbose: bool | None = None) -> bool:
-    """Return all arms to ready configuration.
+def go_home(robot: Geodude, *, arm: str | None = None, verbose: bool | None = None) -> bool:
+    """Return arms to ready configuration.
 
     Args:
         robot: Geodude instance with active execution context.
+        arm: "left", "right", or None (both arms).
+        verbose: Show debug info.
 
     Returns:
-        True if all arms returned to ready.
+        True if all specified arms returned to ready.
     """
     ctx = robot._active_context
     if ctx is None:
@@ -198,8 +200,13 @@ def go_home(robot: Geodude, *, verbose: bool | None = None) -> bool:
 
     from mj_manipulator.cartesian import CartesianController
 
+    if arm is not None:
+        arms = [(arm, robot._resolve_arm(arm))]
+    else:
+        arms = [("left", robot.left_arm), ("right", robot.right_arm)]
+
     success = True
-    for side, arm_obj in [("left", robot.left_arm), ("right", robot.right_arm)]:
+    for side, arm_obj in arms:
         if "ready" not in robot.named_poses or side not in robot.named_poses["ready"]:
             continue
         ready = np.array(robot.named_poses["ready"][side])

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -51,6 +51,36 @@ class _GeodudeSimContext:
         return self._inner.__exit__(*args)
 
 
+class _ArmScope:
+    """Arm-scoped primitives wrapper.
+
+    Returned by ``robot.right`` / ``robot.left``. Delegates to the robot's
+    primitives with a fixed ``arm`` parameter::
+
+        robot.right.pickup("can")   # same as robot.pickup("can", arm="right")
+        robot.left.place("bin")     # same as robot.place("bin", arm="left")
+    """
+
+    def __init__(self, robot: "Geodude", side: str):
+        self._robot = robot
+        self._side = side
+
+    def pickup(self, target: str | None = None, **kwargs) -> bool:
+        return self._robot.pickup(target, arm=self._side, **kwargs)
+
+    def place(self, destination: str | None = None, **kwargs) -> bool:
+        return self._robot.place(destination, arm=self._side, **kwargs)
+
+    def go_home(self, **kwargs) -> bool:
+        from geodude.primitives import go_home
+        return go_home(self._robot, arm=self._side, **kwargs)
+
+    @property
+    def arm(self) -> Arm:
+        """The underlying mj_manipulator Arm."""
+        return self._robot._resolve_arm(self._side)
+
+
 class Geodude:
     """High-level interface for the Geodude bimanual robot.
 
@@ -177,6 +207,16 @@ class Geodude:
         )
 
     # -- Properties ----------------------------------------------------------
+
+    @property
+    def left(self) -> _ArmScope:
+        """Left arm primitives: ``robot.left.pickup("can")``."""
+        return _ArmScope(self, "left")
+
+    @property
+    def right(self) -> _ArmScope:
+        """Right arm primitives: ``robot.right.pickup("can")``."""
+        return _ArmScope(self, "right")
 
     @property
     def left_arm(self) -> Arm:


### PR DESCRIPTION
## Summary

```python
robot.right.pickup("can")    # right arm only
robot.left.place("bin")      # left arm only  
robot.right.go_home()        # right arm only
robot.pickup("can")          # try both (default)
```

`_ArmScope` wrapper delegates to robot primitives with fixed `arm` param.

## Test plan

- [x] 47 tests passing
- [x] `robot.right.pickup("can")` works
- [x] `robot.right.go_home()` works

Closes #77