### PR TITLE
Clean up recycling demo: setup_scene, holding, auto-hide

### DIFF
--- a/examples/recycle.py
+++ b/examples/recycle.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Recycling demo — bimanual pick and place with Geodude.
 
-Demonstrates the full student API::
+Demonstrates the student API::
 
     robot.pickup()                  # pick up anything
     robot.pickup("can")             # pick up any can
-    robot.right.pickup("can")      # right arm picks any can
+    robot.right.pickup("can")       # right arm picks any can
     robot.place("recycle_bin")      # place in any bin
     robot.go_home()
 
@@ -35,8 +35,56 @@ logging.getLogger("toppra").setLevel(logging.WARNING)
 RIGHT_BIN_POS = [0.85, -0.35, 0.01]
 LEFT_BIN_POS = [-0.85, -0.35, 0.01]
 
-# Object geometry from prl_assets
-_ASSETS = AssetManager(str(OBJECTS_DIR))
+
+def spawn_objects(robot: Geodude, object_specs: list[tuple[str, int]]) -> None:
+    """Simulate perception: scatter objects on the worktop.
+
+    Places objects at random collision-free positions on the worktop surface
+    using TSR sampling. In a real setup, object poses would come from a
+    perception system via ``robot.env.registry.activate()``.
+
+    Args:
+        robot: Geodude instance (not yet in sim context).
+        object_specs: List of (object_type, count), e.g.
+            ``[("can", 3), ("potted_meat_can", 1)]``.
+    """
+    assets = AssetManager(str(OBJECTS_DIR))
+
+    wt_id = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "worktop")
+    wt_size = robot.model.site_size[wt_id]
+    worktop_pos = robot.data.site_xpos[wt_id].copy()
+
+    placer = TablePlacer(wt_size[0] - 0.05, wt_size[1] - 0.05)
+    table_surface = np.eye(4)
+    table_surface[:3, 3] = worktop_pos
+
+    for obj_type, count in object_specs:
+        gp = assets.get(obj_type)["geometric_properties"]
+
+        if gp["type"] == "cylinder":
+            templates = placer.place_cylinder(gp["radius"], gp["height"])
+        elif gp["type"] == "box":
+            templates = placer.place_box(gp["size"][0], gp["size"][1], gp["size"][2])
+        else:
+            continue
+
+        for _ in range(count):
+            tsr = templates[0].instantiate(table_surface)
+            pos = tsr.sample()[:3, 3]
+            name = robot.env.registry.activate(obj_type, pos=list(pos))
+            mujoco.mj_forward(robot.model, robot.data)
+
+            # Resample until collision-free
+            body_id = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_BODY, name)
+            jnt_id = robot.model.body_jntadr[body_id]
+            qpos_adr = robot.model.jnt_qposadr[jnt_id]
+            for _ in range(50):
+                if not _has_object_collision(robot.model, robot.data, name):
+                    break
+                robot.data.qpos[qpos_adr : qpos_adr + 3] = tsr.sample()[:3, 3]
+                mujoco.mj_forward(robot.model, robot.data)
+
+    mujoco.mj_forward(robot.model, robot.data)
 
 
 def _has_object_collision(model, data, body_name: str) -> bool:
@@ -56,56 +104,6 @@ def _has_object_collision(model, data, body_name: str) -> bool:
     return False
 
 
-def _spawn_objects(robot, worktop_pos, object_specs: list[tuple[str, int]]):
-    """Spawn objects on the worktop, resampling if in collision.
-
-    Uses MuJoCo's collision checker — place object, mj_forward, check
-    contacts, resample if colliding.
-
-    Args:
-        robot: Geodude instance.
-        worktop_pos: [x, y, z] of worktop surface center.
-        object_specs: list of (object_type, count) e.g. [("can", 3), ("potted_meat_can", 1)]
-    """
-    # Use actual worktop extents (from site size) with margin for object radii
-    wt_id = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "worktop")
-    wt_size = robot.model.site_size[wt_id]
-    table_hx = wt_size[0] - 0.05  # 5cm margin from edges
-    table_hy = wt_size[1] - 0.05
-    placer = TablePlacer(table_hx, table_hy)
-
-    table_surface = np.eye(4)
-    table_surface[:3, 3] = worktop_pos
-
-    for obj_type, count in object_specs:
-        gp = _ASSETS.get(obj_type)["geometric_properties"]
-
-        if gp["type"] == "cylinder":
-            templates = placer.place_cylinder(gp["radius"], gp["height"])
-        elif gp["type"] == "box":
-            templates = placer.place_box(gp["size"][0], gp["size"][1], gp["size"][2])
-        else:
-            continue
-
-        for _ in range(count):
-            tsr = templates[0].instantiate(table_surface)
-            # Activate at a temporary position, then resample until collision-free
-            pos = tsr.sample()[:3, 3]
-            instance_name = robot.env.registry.activate(obj_type, pos=list(pos))
-            mujoco.mj_forward(robot.model, robot.data)
-
-            for _attempt in range(50):
-                if not _has_object_collision(robot.model, robot.data, instance_name):
-                    break
-                # Resample position via freejoint qpos
-                pos = tsr.sample()[:3, 3]
-                body_id = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_BODY, instance_name)
-                jnt_id = robot.model.body_jntadr[body_id]
-                qpos_adr = robot.model.jnt_qposadr[jnt_id]
-                robot.data.qpos[qpos_adr:qpos_adr + 3] = pos
-                mujoco.mj_forward(robot.model, robot.data)
-
-
 def main():
     parser = argparse.ArgumentParser(description="Geodude recycling demo")
     parser.add_argument("--physics", action="store_true")
@@ -121,28 +119,8 @@ def main():
     print(f"{'='*60}\n")
 
     robot = Geodude(objects={"can": args.cans, "potted_meat_can": 1, "recycle_bin": 2})
-
-    # Worktop position for spawning
-    worktop_id = mujoco.mj_name2id(robot.model, mujoco.mjtObj.mjOBJ_SITE, "worktop")
-    worktop_pos = robot.data.site_xpos[worktop_id].copy()
-
-    # Place bins, raise bases to midpoint, set arms to ready
-    robot.env.registry.activate("recycle_bin", pos=RIGHT_BIN_POS)
-    robot.env.registry.activate("recycle_bin", pos=LEFT_BIN_POS)
-    for base in [robot.left_base, robot.right_base]:
-        if base is not None:
-            base.set_height(0.25)  # midpoint of 0–0.5m range
-    for side, arm in [("left", robot.left_arm), ("right", robot.right_arm)]:
-        q = np.array(robot.named_poses["ready"][side])
-        for i, idx in enumerate(arm.joint_qpos_indices):
-            robot.data.qpos[idx] = q[i]
-
-    # Spawn objects on worktop (non-overlapping, TSR-sampled)
-    _spawn_objects(robot, worktop_pos, [
-        ("can", args.cans),
-        ("potted_meat_can", 1),
-    ])
-    mujoco.mj_forward(robot.model, robot.data)
+    robot.setup_scene(fixtures={"recycle_bin": [RIGHT_BIN_POS, LEFT_BIN_POS]})
+    spawn_objects(robot, [("can", args.cans), ("potted_meat_can", 1)])
 
     with robot.sim(physics=args.physics, headless=args.headless) as ctx:
         for cycle in range(1, args.cycles + 1):
@@ -151,42 +129,11 @@ def main():
 
             print(f"\n--- Cycle {cycle} ---")
 
-            # ====================================
-            # THE STUDENT API
-            # ====================================
-
-            # Pick up anything on the table
             if not robot.pickup():
                 print("  Nothing left to pick up")
                 break
 
-            # Which arm grabbed what?
-            for side in ("left", "right"):
-                held = list(robot.grasp_manager.get_grasped_by(side))
-                if held:
-                    holding_side = side
-                    held_object = held[0]
-                    break
-
-            print(f"  {holding_side} arm picked up {held_object}")
-
-            # Place in same-side bin
-            bin_type = "recycle_bin_0" if holding_side == "right" else "recycle_bin_1"
-            if not robot.place(bin_type):
-                print("  Place FAILED")
-                # In kinematic mode, the released object is floating — hide it
-                if not args.physics:
-                    robot.env.registry.hide(held_object)
-                    mujoco.mj_forward(robot.model, robot.data)
-                robot.go_home()
-                continue
-
-            # Hide object and go home
-            robot.env.registry.hide(held_object)
-            mujoco.mj_forward(robot.model, robot.data)
-            ctx.sync()
-            print(f"  Placed in {holding_side} bin")
-
+            robot.place("recycle_bin")
             robot.go_home()
 
         print(f"\nCompleted {cycle} cycles.")

--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import mujoco
 import numpy as np
 import py_trees
 from py_trees.common import Access, Status
@@ -200,12 +201,22 @@ def place(
     if verbose is None:
         verbose = robot.config.debug.verbose
 
+    # Capture held object before the tree releases the grasp
+    held = list(robot.grasp_manager.get_grasped_by(arm))
+    held_object = held[0] if held else None
+
     ns = f"/{arm}"
     bb = _setup_blackboard(robot, ns)
     bb.set(f"{ns}/destination", destination)
     ok = _tick_tree(geodude_place(ns), verbose=verbose)
     if not ok:
         logger.warning("Place failed: %s arm could not place at '%s'", arm, destination)
+
+    # Hide the placed/released object so it doesn't float (kinematic) or clutter
+    if held_object and robot.env.registry.is_active(held_object):
+        robot.env.registry.hide(held_object)
+        mujoco.mj_forward(robot.model, robot.data)
+
     return ok
 
 

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -510,6 +510,61 @@ class Geodude:
             arm_trajectory=arm_traj,
         )
 
+    # -- Scene setup ---------------------------------------------------------
+
+    def setup_scene(
+        self,
+        fixtures: dict[str, list[list[float]]] | None = None,
+    ) -> None:
+        """Set up the scene: place fixtures and ready the robot.
+
+        Activates fixture objects at specified positions, sets bases to
+        midpoint height, and arms to "ready" keyframe.
+
+        Args:
+            fixtures: Stationary objects and their positions, e.g.
+                ``{"recycle_bin": [[0.85, -0.35, 0.01], [-0.85, -0.35, 0.01]]}``
+        """
+        fixtures = fixtures or {}
+
+        # 1. Activate fixtures at specified positions
+        for obj_type, positions in fixtures.items():
+            for pos in positions:
+                self._env.registry.activate(obj_type, pos=list(pos))
+
+        # 2. Set bases to midpoint
+        for base in [self._left_base, self._right_base]:
+            if base is not None:
+                base.set_height(0.25)
+
+        # 3. Set arms to ready keyframe
+        if "ready" in self._named_poses:
+            for side, arm in [("left", self._left_arm), ("right", self._right_arm)]:
+                q = np.array(self._named_poses["ready"][side])
+                for i, idx in enumerate(arm.joint_qpos_indices):
+                    self.data.qpos[idx] = q[i]
+
+        mujoco.mj_forward(self.model, self.data)
+
+    def holding(self) -> tuple[str, str] | None:
+        """Return which arm is holding an object.
+
+        Returns:
+            ``(side, object_name)`` if either arm is holding, else ``None``.
+
+        Example::
+
+            result = robot.holding()
+            if result:
+                side, obj = result
+                print(f"{side} arm is holding {obj}")
+        """
+        for side in ("left", "right"):
+            held = list(self.grasp_manager.get_grasped_by(side))
+            if held:
+                return (side, held[0])
+        return None
+
     # -- Scene queries -------------------------------------------------------
 
     def find_objects(self, target: str | None = None) -> list[str]:


### PR DESCRIPTION
## Summary

- Add `setup_scene(fixtures=...)` to Geodude — places stationary objects at fixed positions, sets bases to midpoint, arms to ready keyframe
- Add `holding()` — returns `(side, object_name)` or `None`
- Auto-hide placed objects inside `place()` — no more manual `registry.hide()` calls
- Rewrite `examples/recycle.py` from ~197 lines to ~70, with object spawning as a standalone `spawn_objects()` function that simulates perception input

Fixtures vs manipulable objects: `setup_scene` handles stationary things (bins, shelves); object spawning stays external since in production it comes from perception.

Fixes #89

## Test plan

- [x] `uv run pytest tests/ -v` — 47 passed
- [x] `uv run mjpython examples/recycle.py --headless --cycles 3` — kinematic mode works
- [ ] `uv run mjpython examples/recycle.py --physics --headless --cycles 2` — physics mode