### PR TITLE
Fix: route base motion through SimContext (physics no longer freezes)

### DIFF
--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -136,9 +136,10 @@ def pickup(
             current = base.get_height()
             target_h = min(current + 0.15, base.height_range[1])
             if target_h > current + 0.01:
-                viewer = getattr(ctx, '_viewer', None)
-                ok = base.move_to(target_h, check_collisions=True, viewer=viewer)
-                if not ok:
+                base_traj = base.plan_to(target_h, check_collisions=True)
+                if base_traj is not None:
+                    ctx.execute(base_traj)
+                else:
                     logger.info("Base lift to %.2fm blocked by collision", target_h)
             ctx.sync()
         return True
@@ -276,11 +277,12 @@ def go_home(robot: Geodude, *, arm: str | None = None, verbose: bool | None = No
             logger.warning("Could not plan %s arm to ready", side)
             success = False
     # Return bases to starting height (0.25 midpoint)
-    viewer = getattr(ctx, '_viewer', None)
     for _, arm_obj in arms:
         base = robot._get_base_for_arm(arm_obj)
         if base is not None and abs(base.get_height() - 0.25) > 0.01:
-            base.move_to(0.25, check_collisions=True, viewer=viewer)
+            base_traj = base.plan_to(0.25, check_collisions=True)
+            if base_traj is not None:
+                ctx.execute(base_traj)
 
     ctx.sync()
     return success

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -320,10 +320,16 @@ class Geodude:
                 ctx.arm("left").grasp("can_0")
         """
         arms = {"left": self._left_arm, "right": self._right_arm}
+        entities = {}
+        if self._left_base is not None:
+            entities[self._left_base.config.name] = self._left_base
+        if self._right_base is not None:
+            entities[self._right_base.config.name] = self._right_base
         inner = SimContext(
             self.model, self.data, arms,
             physics=physics, headless=headless,
             viewer=viewer, viewer_fps=viewer_fps,
+            entities=entities,
         )
         return _GeodudeSimContext(inner, self)
 
@@ -464,28 +470,30 @@ class Geodude:
     ) -> PlanResult | None:
         """Plan with a single arm at a specific base height.
 
-        Moves the base directly (kinematic set_height) before planning
-        the arm, so the planner sees the correct workspace. If planning
-        fails, restores the original base height.
+        Teleports the base for planning (so IK/RRT sees the correct
+        workspace), then restores it. The base trajectory is included
+        in the PlanResult so ctx.execute() moves the base properly
+        through physics/kinematics.
         """
         base = self._get_base_for_arm(arm)
         original_height = None
+        base_traj = None
 
-        # Move base if requested
+        # Plan base trajectory and teleport for arm planning
         if height is not None and base is not None:
             current_height = base.get_height()
             if abs(current_height - height) > 0.001:
-                # Check collision before moving
-                if not base._is_path_collision_free(current_height, height):
-                    return None
+                base_traj = base.plan_to(height, check_collisions=True)
+                if base_traj is None:
+                    return None  # path blocked by collision
                 original_height = current_height
-                base.set_height(height)
+                base.set_height(height)  # teleport for arm planning
 
         # Resolve timeout from config if not specified
         if timeout is None:
             timeout = self.config.planning.timeout
 
-        # Plan arm motion
+        # Plan arm motion (with base at target height)
         try:
             if goal_tsrs is not None:
                 tsrs = goal_tsrs if isinstance(goal_tsrs, list) else [goal_tsrs]
@@ -503,11 +511,17 @@ class Geodude:
                 base.set_height(original_height)
             return None
 
+        # Restore base — execution will move it properly
+        if original_height is not None:
+            base.set_height(original_height)
+
         arm_traj = arm.retime(path)
 
         return PlanResult(
             arm_name=arm.config.name,
             arm_trajectory=arm_traj,
+            base_trajectory=base_traj,
+            base_height=height,
         )
 
     # -- Scene setup ---------------------------------------------------------

--- a/src/geodude/vention_base.py
+++ b/src/geodude/vention_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import mujoco
@@ -73,9 +74,30 @@ class VentionBase:
                 self._arm_body_ids.add(i)
                 self._add_child_bodies(i)
 
+    # -- Entity protocol (for SimContext registration) -----------------------
+
     @property
     def name(self) -> str:
         return self.config.name
+
+    @property
+    def joint_qpos_indices(self) -> list[int]:
+        return [self._qpos_idx]
+
+    @property
+    def joint_qvel_indices(self) -> list[int]:
+        return [self.model.jnt_dofadr[self._joint_id]]
+
+    @property
+    def actuator_ids(self) -> list[int]:
+        return [self._actuator_id]
+
+    @property
+    def grasp_manager(self):
+        """Grasp manager from the associated arm (for attached object tracking)."""
+        return self._arm.grasp_manager
+
+    # -- Height access ------------------------------------------------------
 
     def get_height(self) -> float:
         """Current height in meters."""
@@ -144,13 +166,19 @@ class VentionBase:
     ) -> bool:
         """Move to target height with trapezoidal velocity profile.
 
-        Animates the base motion matching real Vention hardware behavior.
-        Works in both kinematic and physics mode — steps through the
-        trajectory setting qpos and ctrl at each waypoint.
+        .. deprecated::
+            Use ``base.plan_to(height)`` and ``ctx.execute(traj)`` instead.
+            This method bypasses SimContext and freezes physics during motion.
 
         Returns:
             True if movement succeeded, False if blocked by collision.
         """
+        warnings.warn(
+            "VentionBase.move_to() bypasses SimContext and freezes physics. "
+            "Use base.plan_to(height) + ctx.execute(traj) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         traj = self.plan_to(height, check_collisions=check_collisions)
         if traj is None:
             return False


### PR DESCRIPTION
## Summary

- VentionBase gains entity protocol properties for SimContext registration
- `robot.sim()` passes bases as entities to SimContext
- `_plan_single()` populates `base_trajectory` in PlanResult (base-first execution order)
- Primitives use `base.plan_to()` + `ctx.execute()` instead of `move_to()`
- `move_to()` deprecated with warning

## Bug

Physics froze during Vention base movement — `move_to()` called `mj_forward` directly instead of stepping physics. Objects in flight stopped, gripper forces didn't apply, settling paused.

## Fix

Base is now just another entity routed through `ctx.execute()`. Physics continues during base motion.

## Test plan

- [x] `uv run pytest tests/ -v` — 47 passed (5 deprecation warnings from existing `move_to` tests)
- [x] `uv run python examples/recycle.py --headless --cycles 2` — kinematic mode works
- [x] `uv run python examples/recycle.py --headless --cycles 2 --physics` — physics mode works, no freeze

## Depends on

- siddhss5/mj_manipulator#24 (entity executor support)