### PR TITLE
Wire wrist F/T sensors for both arms

### DIFF
--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -174,6 +174,8 @@ class Geodude:
                 acceleration=UR5E_ACCELERATION_LIMITS.copy(),
             ),
             ee_site=spec.ee_site,
+            ft_force_sensor=f"{spec.prefix}/ft_sensor_force",
+            ft_torque_sensor=f"{spec.prefix}/ft_sensor_torque",
         )
 
         # Create arm first to get joint indices for IK solver


### PR DESCRIPTION
## Summary

Pass `ft_force_sensor` and `ft_torque_sensor` to ArmConfig for both UR5e arms. Enables `robot.left_arm.get_ft_wrench()` / `robot.right_arm.get_ft_wrench()`.

## Depends on

- personalrobotics/mj_manipulator#27

## Test plan

- [x] `uv run pytest tests/ -v` — 47 passed
- [x] Smoke test: `robot.left_arm.get_ft_wrench()` returns 13N gravity load in physics mode

Fixes #93