### PR TITLE
Add class-level type annotations for IPython discoverability

### DIFF
--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -99,12 +99,17 @@ class Geodude:
             robot.place("recycle_bin_0")
     """
 
+    config: GeodudConfig
+    model: mujoco.MjModel
+    data: mujoco.MjData
+    grasp_manager: GraspManager
+
     def __init__(
         self,
         config: GeodudConfig | None = None,
         objects: dict[str, int] | None = None,
     ):
-        self.config = config or GeodudConfig.default()
+        self.config: GeodudConfig = config or GeodudConfig.default()
 
         # Load MuJoCo model via mj_environment
         if not self.config.model_path.exists():
@@ -129,11 +134,11 @@ class Geodude:
                 scene_config_yaml=None,
             )
 
-        self.model = self._env.model
-        self.data = self._env.data
+        self.model: mujoco.MjModel = self._env.model
+        self.data: mujoco.MjData = self._env.data
 
         # Shared grasp manager
-        self.grasp_manager = GraspManager(self.model, self.data)
+        self.grasp_manager: GraspManager = GraspManager(self.model, self.data)
 
         # Create arms from mj_manipulator
         self._left_arm = self._create_arm(self.config.left_arm, "left")

--- a/src/geodude/vention_base.py
+++ b/src/geodude/vention_base.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import mujoco
 import numpy as np
 
-from mj_manipulator import Arm, Trajectory
+from mj_manipulator import Arm, GraspManager, Trajectory
 from mj_manipulator.trajectory import create_linear_trajectory
 
 from geodude.config import VentionBaseConfig
@@ -25,6 +25,10 @@ class VentionBase:
     and verifies the path is safe before moving.
     """
 
+    model: mujoco.MjModel
+    data: mujoco.MjData
+    config: VentionBaseConfig
+
     def __init__(
         self,
         model: mujoco.MjModel,
@@ -32,9 +36,9 @@ class VentionBase:
         config: VentionBaseConfig,
         arm: Arm,
     ):
-        self.model = model
-        self.data = data
-        self.config = config
+        self.model: mujoco.MjModel = model
+        self.data: mujoco.MjData = data
+        self.config: VentionBaseConfig = config
         self._arm = arm
 
         # Get joint ID and qpos index
@@ -93,7 +97,7 @@ class VentionBase:
         return [self._actuator_id]
 
     @property
-    def grasp_manager(self):
+    def grasp_manager(self) -> GraspManager | None:
         """Grasp manager from the associated arm (for attached object tracking)."""
         return self._arm.grasp_manager
 


### PR DESCRIPTION
## Summary

Add class-level type annotations to `Geodude` and `VentionBase` so IPython tab completion shows `config`, `model`, `data`, `grasp_manager` attributes.

All 47 tests pass.

Part of personalrobotics/robot-code#1.