### PR TITLE
Log planning exceptions instead of swallowing them

### DIFF
--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -318,7 +318,8 @@ def go_home(robot: Geodude, *, arm: str | None = None, verbose: bool | None = No
         ready = np.array(robot.named_poses["ready"][side])
         try:
             path = arm_obj.plan_to_configuration(ready)
-        except Exception:
+        except Exception as e:
+            logger.info("go_home %s arm: initial plan failed: %s", side, e)
             path = None
 
         if path is None:
@@ -335,7 +336,8 @@ def go_home(robot: Geodude, *, arm: str | None = None, verbose: bool | None = No
             )
             try:
                 path = arm_obj.plan_to_configuration(ready)
-            except Exception:
+            except Exception as e:
+                logger.info("go_home %s arm: retry after retract failed: %s", side, e)
                 path = None
 
         if path is not None:

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -545,7 +545,8 @@ class Geodude:
                 path = arm.plan_to_pose(pose, timeout=timeout, seed=seed)
             else:
                 raise ValueError("Must provide goal_tsrs or pose")
-        except Exception:
+        except Exception as e:
+            logger.info("Planning failed: %s", e)
             path = None
 
         if path is None:


### PR DESCRIPTION
## Summary

Three `except Exception: result = None` patterns now log the exception at INFO level:

- `robot.py`: `_plan_base_and_arm` planning failure
- `primitives.py`: `go_home` initial and retry planning failures

The LLM chat's `_LogCapture` captures these, so the LLM sees "Planning failed: All 100 goal configuration(s) invalid: 100 IK unreachable" instead of just "Failed: pickup({})".

Depends on personalrobotics/mj_manipulator#34 for planning method logging.

## Test plan

- [x] `uv run pytest tests/ -v` — 113 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)