### PR TITLE
Fix misleading pickup failure: distinguish plan vs grasp

### DIFF
--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -159,47 +159,55 @@ def pickup(
             return False
         return True
 
-    def _pickup_details(side: str) -> tuple[list[str], str | None, bool]:
+    def _pickup_details(side: str) -> tuple[list[str], str | None, bool, bool]:
         """Get attempted objects, the specific object reached, and grasp result.
 
         Returns:
-            (attempted_objects, reached_object, grasp_succeeded)
+            (attempted_objects, reached_object, plan_succeeded, grasp_succeeded)
         """
         ns = f"/{side}"
         attempted: list[str] = []
         reached: str | None = None
+        planned = False
         grasped = False
         try:
             bb = py_trees.blackboard.Client(name=f"pickup_report{ns}")
             bb.register_key(key=f"{ns}/tsr_to_object", access=Access.READ)
             bb.register_key(key=f"{ns}/object_name", access=Access.READ)
             bb.register_key(key=f"{ns}/grasped", access=Access.READ)
+            bb.register_key(key=f"{ns}/path", access=Access.READ)
             mapping = bb.get(f"{ns}/tsr_to_object")
             if mapping:
                 attempted = sorted(set(mapping))
             obj = bb.get(f"{ns}/object_name")
             if obj:
                 reached = obj
+            planned = bb.get(f"{ns}/path") is not None
             grasped = bool(bb.get(f"{ns}/grasped"))
         except (KeyError, RuntimeError):
             pass
-        return attempted, reached, grasped
+        return attempted, reached, planned, grasped
 
     def _report_failure(sides_tried: list[str]) -> None:
         all_attempted: set[str] = set()
+        plan_failures: list[str] = []
         grasp_failures: list[str] = []
         for side in sides_tried:
-            attempted, reached, grasped = _pickup_details(side)
+            attempted, reached, planned, grasped = _pickup_details(side)
             all_attempted.update(attempted)
-            if reached and not grasped:
+            if reached and planned and not grasped:
                 grasp_failures.append(f"{reached} ({side} arm)")
+            elif reached and not planned:
+                plan_failures.append(f"{reached} ({side} arm)")
 
         if grasp_failures:
-            unreached = all_attempted - {r.split(" ")[0] for r in grasp_failures}
             msg = f"Pickup failed: reached {', '.join(grasp_failures)} but grasp failed"
-            if unreached:
-                msg += f"; could not plan to {', '.join(sorted(unreached))}"
             logger.warning(msg)
+        elif plan_failures:
+            logger.warning(
+                "Pickup failed: could not plan to %s",
+                ", ".join(plan_failures),
+            )
         elif all_attempted:
             logger.warning(
                 "Pickup failed: could not plan to %s",


### PR DESCRIPTION
## Bug

Pickup failure message said "reached pocky_box_0 but grasp failed" even when the arm never got there — planning itself failed. The blackboard had `object_name` from TSR generation but no `path` (planning never succeeded).

## Fix

Check `path` key on blackboard to distinguish:
- `"could not plan to pocky_box_0 (left arm)"` — planning failed
- `"reached pocky_box_0 (left arm) but grasp failed"` — planned OK, grasp failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)