### PR TITLE
Suppress misleading BT failure message on abort

### DIFF
--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -135,7 +135,7 @@ def _tick_tree(root: py_trees.behaviour.Behaviour, verbose: bool = False) -> boo
 
     if root.status != Status.SUCCESS:
         tip = root.tip()
-        if tip is not None and tip.feedback_message:
+        if tip is not None and tip.feedback_message and tip.feedback_message != "Aborted":
             logger.warning("%s: %s", tip.name, tip.feedback_message)
 
     return root.status == Status.SUCCESS


### PR DESCRIPTION
## Summary
- `_tick_tree` no longer logs the tip node's feedback when the message is "Aborted" — avoids confusing warnings like "PlanToConfig: Planning to configuration failed" when the user intentionally stopped

## Test plan
- [x] 113 tests pass