### PR TITLE
Wire abort + idle event to TeleopPanel

### DIFF
--- a/src/geodude/panels/teleop_panel.py
+++ b/src/geodude/panels/teleop_panel.py
@@ -48,4 +48,6 @@ def create_teleop_panel(
         arm_label=f"{side.title()} Arm",
         abort_fn=robot.is_abort_requested,
         clear_abort_fn=robot.clear_abort,
+        request_abort_fn=robot.request_abort,
+        idle_event=ctx.idle,
     )


### PR DESCRIPTION
## Summary
Passes `robot.request_abort` and `ctx.idle` to `create_teleop_panel()` so TeleopPanel can abort a running trajectory before activating teleop.

## Testing
- [x] 113 tests pass

## Related
Part of personalrobotics/mj_manipulator#51. Depends on mj_manipulator#52 and mj_viser#16.