### PR TITLE
Wire GraspVerifier into Geodude and LiftBase

### DIFF
--- a/src/geodude/bt/nodes.py
+++ b/src/geodude/bt/nodes.py
@@ -12,37 +12,51 @@ from __future__ import annotations
 
 import logging
 
-import mujoco
 import py_trees
-from mj_manipulator.contacts import iter_contacts
 from py_trees.common import Access, Status
 
 logger = logging.getLogger(__name__)
 
 
 class LiftBase(py_trees.behaviour.Behaviour):
-    """Lift the Vention base, then verify the held object is clear of any
-    source surface.
+    """Lift the Vention base, then verify the held object is still held.
 
     The point of this node is to ensure that, after a grasp, the held
-    object is no longer touching whatever it was resting on at grasp
-    time (table, plate, bin floor, etc.). The action is *always* a base
-    lift; the SUCCESS criterion is the post-condition that the held
-    object has no contact with anything other than the arm or gripper.
+    object remains in the gripper after we lift it off its source
+    surface. The action is always a base lift; the SUCCESS criterion
+    is the invariant that the gripper still believes it has the
+    object, as judged by
+    :class:`~mj_manipulator.grasp_verifier.GraspVerifier` on its
+    live sensor signals (wrist F/T for UR5e + Robotiq).
 
-    Why "always lift" rather than "only lift if we see a contact":
-    after the gripper closes via physics, friction often pulls the
-    object 1–2 mm vertically into the gripper, breaking the
-    object↔table contact for that instant. A precondition check that
-    sees zero baseline contacts and skips the lift returns SUCCESS
-    without ever moving the base — exactly the visible bug from
-    geodude#173. The lift is cheap and visible; trust the post-check
-    instead of trying to skip work based on a flaky observation.
+    Why the verifier rather than a contact query:
 
-    The lift is planned with ``partial_ok=True`` so a collision-blocked
-    upper portion still gets us as much travel as is reachable. If even
-    the first step is blocked, or the base is already at max height, we
-    skip the motion and rely on the post-check anyway.
+    - On real hardware there's no MuJoCo contact state to inspect.
+      The verifier uses signals — F/T, gripper position, joint
+      torques — that exist on both sim and real robots.
+    - After a physics grasp, friction can pull the object 1–2 mm
+      into the gripper, breaking any object↔table contact for that
+      instant. A contact-based precondition check sees nothing and
+      skips the lift; that was the visible bug from geodude#173.
+    - The invariant we care about is *\"object is still held\"*, not
+      *\"object stopped touching the table\"*. The verifier answers
+      the former directly. A dropped-during-lift object, a slipped
+      grasp, a gripper that opened too early — all of these failure
+      modes reduce to the same SUCCESS-criterion check: is the
+      verifier still happy?
+
+    Implementation:
+
+    1. **Precondition:** the arm's gripper reports ``is_holding`` —
+       i.e. the verifier thinks we have an object. FAILURE otherwise
+       (config error, BT structure bug, or grasp never succeeded).
+    2. **Action:** plan and execute the lift with
+       ``base.plan_to(target, partial_ok=True)``. If the base is
+       already at max headroom or the first step is in collision,
+       skip the motion and fall straight through to the post-check.
+    3. **Verify post-condition:** re-query ``gripper.is_holding``.
+       FAILURE if it flipped to False during the lift (object
+       dropped); SUCCESS otherwise.
 
     Reads: ``{ns}/robot``, ``{ns}/arm``, ``/context``
     """
@@ -69,20 +83,14 @@ class LiftBase(py_trees.behaviour.Behaviour):
             return Status.FAILURE
 
         gripper = arm.gripper
-        if gripper is None or gripper.held_object is None:
+        if gripper is None or not gripper.is_holding:
             logger.warning(
-                "LiftBase: no held object on arm %s — was Grasp run first?",
+                "LiftBase: gripper on %s arm does not report holding — was Grasp run first?",
                 arm.config.name,
             )
             return Status.FAILURE
 
         held_name = gripper.held_object
-        model = base.model
-        data = base.data
-        held_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, held_name)
-        if held_body_id < 0:
-            logger.warning("LiftBase: held object '%s' not found in model", held_name)
-            return Status.FAILURE
 
         # ----- Action: always attempt the lift -----
         current_h = base.get_height()
@@ -91,7 +99,7 @@ class LiftBase(py_trees.behaviour.Behaviour):
 
         if target_h - current_h < 1e-4:
             logger.warning(
-                "LiftBase: base already at max height %.3fm; skipping lift, will verify clearance",
+                "LiftBase: base already at max height %.3fm; skipping lift, will verify held state",
                 current_h,
             )
         else:
@@ -110,59 +118,14 @@ class LiftBase(py_trees.behaviour.Behaviour):
                     target_h,
                 )
 
-        # ----- Verify post-condition: no source-surface contact -----
-        mujoco.mj_forward(model, data)
-        remaining = self._compute_source_contacts(model, data, base, held_body_id)
-        if remaining:
-            still_touching = self._format_other_bodies(model, remaining, held_body_id)
+        # ----- Verify post-condition: verifier still thinks we hold it -----
+        if not gripper.is_holding:
             logger.warning(
-                "LiftBase: %s still touching %s after lift (base at %.3fm of max %.3fm)",
+                "LiftBase: %s no longer held after lift (base at %.3fm of max %.3fm)",
                 held_name,
-                ", ".join(still_touching),
                 base.get_height(),
                 max_h,
             )
             return Status.FAILURE
 
         return Status.SUCCESS
-
-    # -- Helpers --------------------------------------------------------------
-
-    @staticmethod
-    def _compute_source_contacts(
-        model: mujoco.MjModel,
-        data: mujoco.MjData,
-        base,
-        held_body_id: int,
-    ) -> set[tuple[int, int]]:
-        """Return the set of contact pairs between the held body and a
-        body that is neither the arm nor the gripper.
-
-        These are the "source surface" contacts the lift needs to
-        clear. Pairs are returned in canonical order
-        ``(min(b1, b2), max(b1, b2))`` so set membership is well defined.
-        """
-        arm_and_gripper_ids = base.arm_body_ids
-        out: set[tuple[int, int]] = set()
-        for b1, b2, _ in iter_contacts(model, data):
-            if b1 == b2:
-                continue
-            if b1 == held_body_id and b2 not in arm_and_gripper_ids:
-                out.add((min(b1, b2), max(b1, b2)))
-            elif b2 == held_body_id and b1 not in arm_and_gripper_ids:
-                out.add((min(b1, b2), max(b1, b2)))
-        return out
-
-    @staticmethod
-    def _format_other_bodies(
-        model: mujoco.MjModel,
-        pairs: set[tuple[int, int]],
-        held_body_id: int,
-    ) -> list[str]:
-        """Format the non-held body in each pair as a sorted list of names."""
-        return sorted(
-            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or f"body_{b}"
-            for pair in pairs
-            for b in pair
-            if b != held_body_id
-        )

--- a/src/geodude/bt/nodes.py
+++ b/src/geodude/bt/nodes.py
@@ -70,6 +70,13 @@ class LiftBase(py_trees.behaviour.Behaviour):
         self.bb.register_key(key=f"{ns}/robot", access=Access.READ)
         self.bb.register_key(key=f"{ns}/arm", access=Access.READ)
         self.bb.register_key(key="/context", access=Access.READ)
+        # See mj_manipulator/primitives.py _report_pickup_failure: this
+        # key is read there to distinguish grasp-verification failure
+        # from planning failure in top-level error messages.
+        try:
+            self.bb.register_key(key=f"{ns}/grasp_confirmed", access=Access.WRITE)
+        except KeyError:
+            pass
 
     def update(self) -> Status:
         robot = self.bb.get(f"{self.ns}/robot")
@@ -84,18 +91,31 @@ class LiftBase(py_trees.behaviour.Behaviour):
 
         gripper = arm.gripper
         if gripper is None or not gripper.is_holding:
+            # The verifier ran its first post-settling check during
+            # the preceding Sync / plan_and_execute ticks and
+            # rejected the grasp, OR nothing was grasped to begin
+            # with. Either way: the grasp didn't hold. Record the
+            # verdict so _report_pickup_failure can classify this as
+            # \"reached X but verifier rejected the grasp\" instead
+            # of \"could not plan to X\".
+            self.bb.set(f"{self.ns}/grasp_confirmed", False)
             logger.warning(
-                "LiftBase: gripper on %s arm does not report holding — was Grasp run first?",
+                "LiftBase: verifier on %s arm rejected the grasp (nothing to lift)",
                 arm.config.name,
             )
             return Status.FAILURE
 
+        # Precondition passed — verifier says we're holding. Record
+        # the confirmation. Subsequent failures in this node are
+        # dropped-during-lift, not grasp-close failures.
+        self.bb.set(f"{self.ns}/grasp_confirmed", True)
         held_name = gripper.held_object
 
         # ----- Action: always attempt the lift -----
         current_h = base.get_height()
         max_h = base.height_range[1]
         target_h = min(current_h + self.LIFT_AMOUNT, max_h)
+        start_h = current_h
 
         if target_h - current_h < 1e-4:
             logger.warning(
@@ -120,12 +140,26 @@ class LiftBase(py_trees.behaviour.Behaviour):
 
         # ----- Verify post-condition: verifier still thinks we hold it -----
         if not gripper.is_holding:
-            logger.warning(
-                "LiftBase: %s no longer held after lift (base at %.3fm of max %.3fm)",
-                held_name,
-                base.get_height(),
-                max_h,
-            )
+            end_h = base.get_height()
+            lift_traveled = end_h - start_h
+            if lift_traveled < 0.005:
+                # Base barely moved — the abort-on-drop predicate
+                # caught the verifier transition within a tick or two
+                # of the trajectory starting. The grasp wasn't really
+                # holding and there was nothing to transport.
+                logger.warning(
+                    "LiftBase: %s slipped immediately after grasp (base at %.3fm, did not lift)",
+                    held_name,
+                    end_h,
+                )
+            else:
+                logger.warning(
+                    "LiftBase: %s dropped during lift (base moved %.3fm to %.3fm of max %.3fm)",
+                    held_name,
+                    lift_traveled,
+                    end_h,
+                    max_h,
+                )
             return Status.FAILURE
 
         return Status.SUCCESS

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -28,6 +28,8 @@ from mj_manipulator.arms.ur5e import (
     UR5E_VELOCITY_LIMITS,
 )
 from mj_manipulator.config import ArmConfig, KinematicLimits
+from mj_manipulator.grasp_verifier import GraspVerifier
+from mj_manipulator.load_signals import GripperPositionSignal
 
 from geodude.config import GeodudConfig, GeodudeArmSpec, setup_logging
 from geodude.vention_base import VentionBase
@@ -371,13 +373,39 @@ class Geodude:
             grasp_manager=self.grasp_manager,
         )
 
-        return Arm(
+        arm = Arm(
             self._env,
             arm_config,
             ik_solver=ik_solver,
             gripper=gripper,
             grasp_manager=self.grasp_manager,
         )
+
+        # Attach a sensor-based grasp verifier so gripper.is_holding /
+        # gripper.held_object reflect real signals instead of stale
+        # GraspManager bookkeeping.
+        #
+        # The single primary signal is the Robotiq gripper position.
+        # With RobotiqGripper.empty_at_fully_closed=True (set in
+        # mj_manipulator after the investigation recorded in
+        # geodude#173), the verifier's decisive-negative branch fires
+        # immediately when the gripper closed on nothing — crisp,
+        # noise-free, pose-independent, motion-independent. The F/T
+        # sensor is deliberately *not* wired up as a verifier signal:
+        # it produces false LOST transitions from inertial forces
+        # during transport and stale baselines from physics settling.
+        # F/T-based monitoring would need a quiescence gate to work
+        # reliably; deferred until we actually need finer-grained
+        # drop detection than "gripper fully closed means no object".
+        #
+        # See personalrobotics/mj_manipulator#93, #98, #99, #101 for
+        # the full story.
+        gripper.grasp_verifier = GraspVerifier(
+            gripper=gripper,
+            signals=[GripperPositionSignal(gripper)],
+        )
+
+        return arm
 
     # -- Properties ----------------------------------------------------------
 

--- a/tests/test_lift_base.py
+++ b/tests/test_lift_base.py
@@ -3,10 +3,17 @@
 
 """Tests for ``geodude.bt.nodes.LiftBase``.
 
-LiftBase is a thin orchestrator: precondition checks → lift → verify
-post-condition. Two integration tests against a real :class:`Geodude` +
-:class:`SimContext` cover the failure mode and the regression. The
-contact-clearing happy path is exercised end-to-end by the recycling
+LiftBase is a thin orchestrator: precondition (gripper reports
+holding) → lift → verify post-condition (gripper still reports
+holding). Both halves go through
+:class:`~mj_manipulator.grasp_verifier.GraspVerifier`, which the
+geodude arm factory wires up with a wrist F/T signal per
+personalrobotics/mj_manipulator#93. The tests below drive the
+verifier directly (``gripper.grasp_verifier.mark_grasped(...)``) to
+simulate a completed grasp without running the full physics close
+sequence.
+
+The drop-during-lift end-to-end path is exercised by the recycling
 demo per geodude#173's acceptance criteria.
 """
 
@@ -50,35 +57,44 @@ class TestLiftBaseIntegration:
         """A freshly-loaded robot has no held object, so LiftBase should
         return FAILURE without touching the base. Verifies the
         precondition guard and that the orchestrator wires up the
-        blackboard correctly."""
+        blackboard correctly.
+        """
         robot = Geodude()
         with robot.sim(headless=True) as ctx:
             node = _make_node(robot, ctx)
             assert node.update() == Status.FAILURE
 
-    def test_lift_happens_even_when_no_baseline_contacts_detected(self):
+    def test_lift_happens_when_verifier_reports_held(self):
         """Regression for geodude#173: LiftBase used to skip the lift
-        entirely when it observed zero source-surface contacts at start
-        time, returning SUCCESS without moving the base. After a real
-        physics grasp, friction often pulls the held object 1–2 mm into
-        the gripper, breaking the object↔table contact for that
-        instant — exactly the case the precondition check missed.
+        entirely when its contact-based precondition check saw zero
+        source-surface contacts at start, returning SUCCESS without
+        moving the base. After a real physics grasp, friction often
+        pulls the held object 1–2 mm into the gripper, breaking the
+        object↔table contact for that instant — exactly the case the
+        precondition check missed.
 
-        We simulate that situation by marking a held object whose body
-        has no source-surface contacts (the vention_base body itself,
-        which only touches the arm — filtered by ``arm_body_ids``). The
-        regression assertion is that the base height *increased*, i.e.
-        LiftBase actually attempted the lift instead of bailing out
-        early on the empty-baseline observation.
+        The fix (both the #173 mitigation and the #93 verifier-based
+        rewrite) is to treat the lift as the action and the verifier's
+        held-state as the post-condition. Always lift, then verify.
+
+        We simulate a completed grasp by driving the verifier
+        directly: ``mark_grasped`` records a baseline from the F/T
+        signal. In kinematic sim the signal returns None, so the
+        verifier degenerates to \"trust that mark_grasped was called\"
+        — which is what we want for this test since the lift itself
+        is the property under test, not the drop-detection path.
+        The drop-detection path is exercised at integration time by
+        the recycling demo.
         """
         robot = Geodude()
         with robot.sim(headless=True) as ctx:
             arm = robot.arms["left"]
-            # Mark a real model body as "grasped" so gripper.held_object
-            # resolves to a valid body. vention_base touches only arm
-            # bodies (filtered), so the post-check sees zero source
-            # contacts and returns SUCCESS.
-            arm.grasp_manager.mark_grasped("vention_base", arm.config.name)
+            # vention_base is a real body that happens to be a
+            # convenient stand-in: its only contacts are with the arm
+            # (filtered by the verifier implicitly because we never
+            # look at contacts) and it's guaranteed to exist.
+            arm.gripper.grasp_verifier.mark_grasped("vention_base")
+            assert arm.gripper.is_holding is True
 
             node = _make_node(robot, ctx)
             start_h = robot.left_base.get_height()
@@ -89,3 +105,41 @@ class TestLiftBaseIntegration:
                 "LiftBase did not move the base — the empty-baseline early-return regression from #173 is back"
             )
             assert result == Status.SUCCESS
+
+    def test_object_dropped_during_lift_returns_failure(self):
+        """Regression for the core geodude#173 bug class: if the
+        gripper loses the object during the lift, LiftBase must
+        return FAILURE so the BT recovery path fires.
+
+        We simulate the drop by wrapping ``ctx.execute`` to call
+        ``verifier.mark_released`` as a side effect — i.e. by the
+        time execution returns, the verifier reports \"not held\".
+        The post-check then re-queries ``gripper.is_holding``, sees
+        False, and returns FAILURE.
+
+        This is the contract LiftBase owes the BT: the post-check
+        is authoritative. If you change LiftBase to skip the
+        post-check or to return SUCCESS based on something the
+        verifier disagrees with, this test breaks.
+        """
+        robot = Geodude()
+        with robot.sim(headless=True) as ctx:
+            arm = robot.arms["left"]
+            arm.gripper.grasp_verifier.mark_grasped("vention_base")
+            assert arm.gripper.is_holding is True
+
+            # Wrap ctx.execute so that the verifier is cleared as a
+            # side effect of the lift — this is what a real dropped
+            # object looks like from LiftBase's perspective.
+            original_execute = ctx.execute
+
+            def execute_then_drop(*args, **kwargs):
+                result = original_execute(*args, **kwargs)
+                arm.gripper.grasp_verifier.mark_released()
+                return result
+
+            ctx.execute = execute_then_drop
+
+            node = _make_node(robot, ctx)
+            assert node.update() == Status.FAILURE
+            assert arm.gripper.is_holding is False


### PR DESCRIPTION
Follow-up to personalrobotics/mj_manipulator#96 / #99 / #101. First consumer of the GraspVerifier infrastructure and the geodude-side completion of the #173 fix. **Replaces #178**, which was closed when the v1 live-query verifier design proved insufficient.

## What lands

### Verifier wiring ([robot.py](src/geodude/robot.py))

In \`Geodude._create_arm\`, after constructing the \`Arm\` + \`RobotiqGripper\`, attach a \`GraspVerifier\` with a single \`GripperPositionSignal\`:

\`\`\`python
gripper.grasp_verifier = GraspVerifier(
    gripper=gripper,
    signals=[GripperPositionSignal(gripper)],
)
\`\`\`

With \`RobotiqGripper.empty_at_fully_closed=True\` (set in personalrobotics/mj_manipulator#101), the verifier's decisive-negative branch fires immediately when the gripper closed on nothing — a crisp, noise-free, pose-independent, motion-independent signal.

**Why not WristFTSignal:** initial attempts to use it produced false LOST transitions in the live recycling demo:
- **Stale baselines** — \`spam_can_1\` baselined at −13.1 N, an order of magnitude higher than its actual weight. Tare leaked gripper self-weight or residual load.
- **Inertial forces during transport** — \`cracker_box_0\` went from baseline −1.9 N to −0.9 N mid-motion purely from arm acceleration. Grip was perfectly healthy.

F/T-based monitoring would need a quiescence gate to work reliably; deferred until we actually need finer-grained drop detection than \"gripper fully closed means no object\".

### LiftBase rewrite ([bt/nodes.py](src/geodude/bt/nodes.py))

The node shrinks from ~280 lines of contact-inspection helpers to ~120 lines of pure orchestration:

1. **Precondition**: \`gripper.is_holding\` (verifier reports held)
2. **Action**: \`plan_to(target, partial_ok=True)\` + \`ctx.execute\`
3. **Post-condition**: \`gripper.is_holding\` again

Gone: \`_compute_source_contacts\`, \`_format_other_bodies\`, \`iter_contacts\`, \`arm_body_ids\` filtering, the whole \"what counts as a source surface\" problem. The invariant becomes *\"did the gripper keep the object?\"* — a sensor question the verifier already answers.

As a free benefit, the post-check catches failure modes the old contact-based version never did: gripper slipped during close, slipped mid-lift, opened too early. All reduce to *\"verifier is unhappy\"* → recovery path fires.

### Tests ([test_lift_base.py](tests/test_lift_base.py))

| Test | Purpose |
|---|---|
| \`test_no_held_object_returns_failure\` | Precondition guard via \`gripper.is_holding\` (now verifier-backed) |
| \`test_lift_happens_when_verifier_reports_held\` | Regression for the visible #173 bug — base never moved |
| \`test_object_dropped_during_lift_returns_failure\` | New: wraps \`ctx.execute\` to \`mark_released\` as a side effect, so the post-check sees a dropped-mid-lift object and returns FAILURE |

End-to-end drop detection via real signals in the recycling demo is the acceptance criteria per #173.

## Dependencies (must land first)

- personalrobotics/mj_manipulator#101 — RobotiqGripper \`empty_at_fully_closed = True\` (open, unmerged, waiting for user verification)

Without #101, the decisive-negative branch won't fire on Robotiq, and the verifier will silently accept failed grasps (degenerates to \"trust mark_grasped\").

## Test plan

- [x] \`uv run pytest tests/ -q\` → 136 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI 3.10 / 3.11 / 3.12
- [ ] **Do not merge until @siddh verifies in the recycling demo:**
  - [ ] \`robot.pickup(\"can\")\` returns True AND the base actually moves, consistently across multiple attempts
  - [ ] Grasping on empty space rejects correctly (force an empty grasp and confirm the verifier fires LOST)
  - [ ] No false LOST transitions during normal transport motion
  - [ ] \`sort_all()\` completes without spurious failures

## Related

- personalrobotics/mj_manipulator#93 / #96 — GraspVerifier v1
- personalrobotics/mj_manipulator#99 — state machine refactor
- personalrobotics/mj_manipulator#101 — Robotiq flag flip (prereq)
- personalrobotics/mj_manipulator#100 — WristFTSignal → world Z (open, will stay unmerged — pivoted away from F/T)
- #173 — motivating bug
- #177 — sim-magic elimination meta-issue
- #178 — v1 wiring, closed