### PR TITLE
BT recovery refactor + GraspVerifier tuning for stable demos

### DIFF
--- a/src/geodude/bt/nodes.py
+++ b/src/geodude/bt/nodes.py
@@ -119,9 +119,11 @@ class LiftBase(py_trees.behaviour.Behaviour):
 
         if target_h - current_h < 1e-4:
             logger.warning(
-                "LiftBase: base already at max height %.3fm; skipping lift, will verify held state",
+                "LiftBase: base already at max height %.3fm; cannot lift %s",
                 current_h,
+                held_name,
             )
+            return Status.FAILURE
         else:
             traj = base.plan_to(target_h, check_collisions=True, partial_ok=True)
             if traj is None:
@@ -129,6 +131,7 @@ class LiftBase(py_trees.behaviour.Behaviour):
                     "LiftBase: cannot plan any base motion from %.3fm — first step blocked",
                     current_h,
                 )
+                return Status.FAILURE
             else:
                 ctx.execute(traj)
                 logger.info(

--- a/src/geodude/bt/subtrees.py
+++ b/src/geodude/bt/subtrees.py
@@ -4,20 +4,22 @@
 """Geodude-specific behavior tree subtrees.
 
 Extends mj_manipulator.bt subtrees with bimanual arm selection
-and automatic TSR generation.
+and automatic TSR generation. These are action sequences — recovery
+on failure is handled by the primitives layer (``robot.pickup()``,
+``robot.place()``).
 """
 
 from __future__ import annotations
 
 import py_trees
-from mj_manipulator.bt import pickup_with_recovery, place_with_recovery
+from mj_manipulator.bt import pickup, place
 from mj_manipulator.bt.nodes import GenerateGrasps, GeneratePlaceTSRs
 
 from geodude.bt.nodes import LiftBase
 
 
 def geodude_pickup(ns: str) -> py_trees.composites.Sequence:
-    """Generate grasp TSRs then pickup with recovery.
+    """Generate grasp TSRs, pickup, then lift the base.
 
     Geodude's UR5e is mounted on a Vention linear base with generous vertical
     clearance, so post-grasp retraction is done by :class:`LiftBase` (base up)
@@ -27,31 +29,31 @@ def geodude_pickup(ns: str) -> py_trees.composites.Sequence:
     benefit.
 
     Reads: ``{ns}/object_name``, ``{ns}/robot``
-    (plus all blackboard keys needed by pickup_with_recovery)
+    (plus all blackboard keys needed by pickup)
     """
     return py_trees.composites.Sequence(
         name="geodude_pickup",
         memory=True,
         children=[
             GenerateGrasps(ns=ns),
-            pickup_with_recovery(ns, with_lift=False),
+            pickup(ns, with_lift=False),
             LiftBase(ns=ns),
         ],
     )
 
 
 def geodude_place(ns: str) -> py_trees.composites.Sequence:
-    """Generate placement TSRs then place with recovery.
+    """Generate placement TSRs then place.
 
     Reads: ``{ns}/destination``, ``{ns}/robot``
-    (plus all blackboard keys needed by place_with_recovery)
+    (plus all blackboard keys needed by place)
     """
     return py_trees.composites.Sequence(
         name="geodude_place",
         memory=True,
         children=[
             GeneratePlaceTSRs(ns=ns),
-            place_with_recovery(ns),
+            place(ns),
         ],
     )
 

--- a/src/geodude/demos/recycling.py
+++ b/src/geodude/demos/recycling.py
@@ -35,6 +35,6 @@ _GRASPABLE_TYPES = [k for k in scene["objects"] if k != "recycle_bin"]
 def sort_all():
     """Pick up and place every object into a recycle bin."""
     while robot.pickup():
-        if not robot.place("recycle_bin"):
-            robot.go_home()
+        robot.place("recycle_bin")
+        robot.go_home()
     robot.go_home()

--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -19,6 +19,7 @@ import py_trees
 from mj_manipulator.primitives import (
     _arm_preempted,
     _deactivate_teleop_for_arms,
+    _recover,
     _report_pickup_failure,
     _set_hud_action,
     _setup_blackboard,
@@ -83,6 +84,14 @@ def _pickup_inner(
 
     ctx = robot._active_context
 
+    # Ensure grippers are open before planning. A closed gripper from
+    # a previous failed grasp causes start-config collisions when the
+    # planner tries to approach a new object.
+    for side_name in ("left", "right"):
+        arm_obj = robot.arms[side_name]
+        if arm_obj.gripper is not None and arm_obj.gripper.get_actual_position() > 0.1:
+            ctx.arm(side_name).release()
+
     # Quick check: are there any matching objects?
     if not robot.find_objects(target):
         desc = f"'{target}'" if target else "any object"
@@ -111,6 +120,7 @@ def _pickup_inner(
             _sync_viewer(robot)
             return True
         _report_pickup_failure(robot, [arm], target)
+        _recover(robot, ctx, [arm])
         _sync_viewer(robot)
         return False
 
@@ -130,9 +140,7 @@ def _pickup_inner(
             go_home(robot, arm=side)
 
     _report_pickup_failure(robot, sides_tried, target)
-    for side in sides_tried:
-        if not _arm_preempted(robot, side):
-            go_home(robot, arm=side)
+    _recover(robot, ctx, sides_tried)
     _sync_viewer(robot)
     return False
 
@@ -217,6 +225,7 @@ def _place_inner(
     else:
         _set_hud_action(robot, arm, f"✗ place({desc})")
         logger.warning("Place failed for destination '%s'", destination)
+        _recover(robot, ctx, [arm])
 
     _sync_viewer(robot)
     return ok
@@ -273,6 +282,16 @@ def _go_home_inner(
             logger.warning("go_home: no 'ready' pose for %s arm, skipping", side)
             continue
         ready = np.array(robot.named_poses["ready"][side])
+
+        # Release before planning home. This does two things:
+        # 1. Opens a closed gripper so the planner doesn't see
+        #    start-config collisions from closed fingers.
+        # 2. Puts the verifier in IDLE so the abort-on-drop
+        #    predicate doesn't fire during go_home's trajectory
+        #    execution (verifier was falsely going LOST from
+        #    finger compliance drift during transit).
+        ctx.arm(side).release()
+
         try:
             path = arm_obj.plan_to_configuration(ready, abort_fn=abort_fn)
         except Exception as e:

--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -130,6 +130,9 @@ def _pickup_inner(
             go_home(robot, arm=side)
 
     _report_pickup_failure(robot, sides_tried, target)
+    for side in sides_tried:
+        if not _arm_preempted(robot, side):
+            go_home(robot, arm=side)
     _sync_viewer(robot)
     return False
 

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -29,7 +29,6 @@ from mj_manipulator.arms.ur5e import (
 )
 from mj_manipulator.config import ArmConfig, KinematicLimits
 from mj_manipulator.grasp_verifier import GraspVerifier
-from mj_manipulator.load_signals import GripperPositionSignal
 
 from geodude.config import GeodudConfig, GeodudeArmSpec, setup_logging
 from geodude.vention_base import VentionBase
@@ -385,24 +384,27 @@ class Geodude:
         # gripper.held_object reflect real signals instead of stale
         # GraspManager bookkeeping.
         #
-        # The single primary signal is the Robotiq gripper position.
-        # With RobotiqGripper.empty_at_fully_closed=True (set in
-        # mj_manipulator after the investigation recorded in
-        # geodude#173), the verifier's decisive-negative branch fires
-        # immediately when the gripper closed on nothing — crisp,
-        # noise-free, pose-independent, motion-independent. The F/T
-        # sensor is deliberately *not* wired up as a verifier signal:
-        # it produces false LOST transitions from inertial forces
-        # during transport and stale baselines from physics settling.
-        # F/T-based monitoring would need a quiescence gate to work
-        # reliably; deferred until we actually need finer-grained
-        # drop detection than "gripper fully closed means no object".
+        # The grasp verifier uses no load signals — the only check is
+        # the decisive-negative branch (gripper at mechanical stop →
+        # nothing held), which reads gripper.get_actual_position()
+        # directly inside _collect_facts, not through the signal list.
         #
-        # See personalrobotics/mj_manipulator#93, #98, #99, #101 for
-        # the full story.
+        # GripperPositionSignal was previously in the signal list, but
+        # the load-drop check (|val| < |baseline| * 0.7) is wrong for
+        # position: tiny compliance drift (fingers flex ~0.06 rad
+        # under load) triggers false LOST on objects grasped at low
+        # position values (pop_tarts_case_0 at 0.209 → 0.146 drift).
+        # The object is still firmly held; the fingers just flexed.
+        #
+        # With an empty signal list, the verifier has one check:
+        # "did the gripper reach the mechanical stop?" If yes → LOST.
+        # If no → HOLDING. Delayed detection of a mid-transport drop
+        # (object falls out, fingers close to stop) is acceptable —
+        # the decisive-negative fires within a few ticks once the
+        # fingers close through the now-empty space.
         gripper.grasp_verifier = GraspVerifier(
             gripper=gripper,
-            signals=[GripperPositionSignal(gripper)],
+            signals=[],
         )
 
         return arm

--- a/tests/bench_physics_step.py
+++ b/tests/bench_physics_step.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Headless benchmark: per-step timing with and without GraspVerifier.
+
+Measures the wall-clock time of a single PhysicsController._step_physics
+call across 1000 iterations, first with the verifier attached (current
+state) and then with the verifier detached. Reports mean, p50, p99,
+and max per-step times in microseconds.
+
+Also benchmarks a full event-loop tick cycle to see the total overhead
+from the verifier in context.
+
+Run:
+    cd /Users/siddh/code/robot-code/geodude
+    uv run python tests/bench_physics_step.py
+"""
+
+import time
+
+import numpy as np
+
+from geodude.robot import Geodude
+
+
+def bench_step(robot, ctx, label, n=1000):
+    """Time n physics steps, return per-step times in microseconds."""
+    controller = ctx._controller
+    if controller is None:
+        print(f"  {label}: no physics controller (kinematic mode), skipping")
+        return None
+
+    times = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        controller.step()
+        t1 = time.perf_counter()
+        times.append((t1 - t0) * 1e6)  # microseconds
+
+    times = np.array(times)
+    print(
+        f"  {label}: mean={times.mean():.1f}µs  "
+        f"p50={np.median(times):.1f}µs  "
+        f"p99={np.percentile(times, 99):.1f}µs  "
+        f"max={times.max():.1f}µs  "
+        f"(n={n})"
+    )
+    return times
+
+
+def bench_tick_overhead(robot, ctx, label, n=1000):
+    """Time what the verifier tick itself costs, isolated."""
+    times = []
+    for side in ("left", "right"):
+        arm = robot.arms[side]
+        v = arm.gripper.grasp_verifier
+        if v is None:
+            continue
+        for _ in range(n):
+            t0 = time.perf_counter()
+            v.tick()
+            t1 = time.perf_counter()
+            times.append((t1 - t0) * 1e6)
+
+    if not times:
+        print(f"  {label}: no verifiers configured")
+        return None
+
+    times = np.array(times)
+    print(
+        f"  {label}: mean={times.mean():.3f}µs  "
+        f"p50={np.median(times):.3f}µs  "
+        f"p99={np.percentile(times, 99):.3f}µs  "
+        f"max={times.max():.3f}µs  "
+        f"(n={len(times)}, both arms)"
+    )
+    return times
+
+
+def main():
+    robot = Geodude()
+    print(f"Geodude loaded: {robot.model.nbody} bodies, {robot.model.njnt} joints\n")
+
+    with robot.sim(headless=True, physics=True) as ctx:
+        # Warm up — let physics settle
+        controller = ctx._controller
+        for _ in range(100):
+            controller.step()
+
+        # ---- Benchmark 1: verifier tick overhead in isolation ----
+        print("=== Verifier tick overhead (isolated) ===")
+        bench_tick_overhead(robot, ctx, "IDLE state (no grasp)")
+
+        # Mark a fake grasp so the verifier is in HOLDING
+        for side in ("left", "right"):
+            v = robot.arms[side].gripper.grasp_verifier
+            if v is not None:
+                v.mark_grasped("fake_object")
+        bench_tick_overhead(robot, ctx, "HOLDING state (settling window)")
+
+        # Burn through the settling window
+        for _ in range(10):
+            for side in ("left", "right"):
+                v = robot.arms[side].gripper.grasp_verifier
+                if v is not None:
+                    v.tick()
+        bench_tick_overhead(robot, ctx, "HOLDING state (post-settling, real verification)")
+
+        # Release
+        for side in ("left", "right"):
+            v = robot.arms[side].gripper.grasp_verifier
+            if v is not None:
+                v.mark_released()
+
+        # ---- Benchmark 2: full physics step with verifier ----
+        print("\n=== Full physics step (controller.step) ===")
+        bench_step(robot, ctx, "WITH verifier (IDLE)")
+
+        # ---- Benchmark 3: detach verifiers and re-measure ----
+        saved_verifiers = {}
+        for side in ("left", "right"):
+            gripper = robot.arms[side].gripper
+            saved_verifiers[side] = gripper.grasp_verifier
+            gripper.grasp_verifier = None
+
+        bench_step(robot, ctx, "WITHOUT verifier")
+
+        # Restore
+        for side, v in saved_verifiers.items():
+            robot.arms[side].gripper.grasp_verifier = v
+
+        # ---- Benchmark 4: with verifier in HOLDING + real verification ----
+        for side in ("left", "right"):
+            v = robot.arms[side].gripper.grasp_verifier
+            if v is not None:
+                v.mark_grasped("fake_object")
+        # Burn through settling
+        for _ in range(10):
+            controller.step()
+
+        bench_step(robot, ctx, "WITH verifier (HOLDING, verifying)")
+
+        for side in ("left", "right"):
+            v = robot.arms[side].gripper.grasp_verifier
+            if v is not None:
+                v.mark_released()
+
+        # ---- Summary ----
+        print("\n=== Comparison ===")
+        print("If the WITH/WITHOUT difference is < 10µs per step, the")
+        print("verifier tick is not the jitter source and we need to")
+        print("look elsewhere (event loop, viewer sync, teleop IK, etc.)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Companion to personalrobotics/mj_manipulator#109. Geodude-side changes for the BT recovery refactor, plus GraspVerifier signal tuning discovered during recycling-demo testing.

## BT subtree changes

**`geodude_pickup(ns)`**: `pickup_with_recovery(ns, with_lift=False)` → `pickup(ns, with_lift=False)`

**`geodude_place(ns)`**: `place_with_recovery(ns)` → `place(ns)`

Both subtrees are now pure action sequences — no recovery. Recovery is handled by the primitives layer via `_recover`.

## Primitives changes

**`_pickup_inner`:**
- Import and use `_recover` from mj_manipulator for all failure paths
- Open closed grippers before planning (prevents start-config collisions from a previous failed grasp)
- Added missing recovery on single-arm failure path (was relying on the now-deleted BT `recover` subtree)

**`_place_inner`:**
- Use `_recover` on place failure

**`go_home`:**
- Release gripper *before* planning home, not after. Prevents two problems: (1) closed-finger start-config collisions in the planner, (2) the abort-on-drop predicate firing during go_home's trajectory because the verifier was still in HOLDING state from the failed grasp.

## GraspVerifier tuning (signal list)

Changed from `signals=[GripperPositionSignal(gripper)]` to `signals=[]`.

**Why:** The `GripperPositionSignal` participated in the verifier's load-drop check (`|val| < |baseline| * 0.7`), which is wrong for gripper position. Tiny compliance drift (fingers flex ~0.06 rad under load during transport) triggered false LOST transitions on objects grasped at low position values. Specifically observed: `pop_tarts_case_0` at baseline 0.209 drifted to 0.146 during motion — the object was still firmly held, but the 30% drop check fired.

With an empty signal list, the verifier has exactly one check: the decisive-negative branch ("did the gripper reach the mechanical stop?"). This reads `gripper.get_actual_position()` directly inside `_collect_facts()`, not through the signal list. The result:

- `pos >= 0.98` → LOST (fingers closed on nothing, or object fell out and fingers closed)
- `pos < 0.98` → HOLDING (something is between the fingers)

No false positives from compliance drift. Delayed detection of mid-transport drops (object falls out → fingers close through empty space → pos reaches 0.98) is acceptable — takes a few ticks, not seconds.

## LiftBase changes

**Return FAILURE when the base can't lift.** Previously, when `base.plan_to()` returned None (first step blocked by collision) or the base was already at max height, LiftBase fell through to the post-check and returned SUCCESS if the gripper still reported holding. This meant `place()` would proceed with the object still on the table, producing aggressive arm motions that dragged the object through the scene.

Now both paths return FAILURE immediately:
- Base at max height → FAILURE with "cannot lift"
- First step blocked → FAILURE with "first step blocked"

The `pickup()` call returns False and `_recover` fires, cleaning up for the next attempt.

## Demo changes

**`sort_all()`** now calls `robot.go_home()` between successful pickup/place cycles:
```python
def sort_all():
    while robot.pickup():
        robot.place("recycle_bin")
        robot.go_home()
    robot.go_home()
```

Without this, the Vention base ratchets up with each LiftBase call (0.25m → 0.40m → 0.50m) and never returns to midpoint. After 2 cycles the base hits max height and LiftBase can't plan. `go_home` returns the base to 0.25m. This is user-controlled — the demo decides its own cycle. The primitives stay pure (don't go home on success).

## Benchmark

Added `tests/bench_physics_step.py` — headless benchmark that measures per-step timing with and without the GraspVerifier. Results showed the verifier adds ~10 µs/step (0.1% of the 8 ms control budget), confirming the teleop jitter was NOT caused by the verifier (it was the velocity-limit issue fixed in personalrobotics/mj_manipulator#107).

## Known limitations (not bugs — filed separately)

- **Flat objects on the table** (gelatin_box): the gripper fingers dip below the table surface when grasping, causing the base collision checker to reject the lift. This is a grasp-pose quality issue (TSR templates), not a recovery or verifier issue.
- **Thin cylindrical objects** (fuze_bottle at pos=0.983): borderline grasps where the gripper is almost fully closed. The decisive-negative threshold (0.98) correctly rejects these — the object is barely held and likely to slip during transport.

## Test plan

- [x] `uv run pytest tests/ -q` → 136 passed
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [ ] CI
- [x] `sort_all()` recycling demo: successful cycles complete with go_home between them; failed grasps recover cleanly; base height resets between cycles
- [x] Verifier correctly detects empty grasps (pos=1.000) and marginal grasps (pos≥0.98)
- [x] No false LOST transitions from gripper compliance drift during transport

## Related

- personalrobotics/mj_manipulator#109 — companion PR (must land together)
- personalrobotics/mj_manipulator#104 — recovery policy issue (this PR implements the immediate fix + architecture)
- personalrobotics/geodude#173 — the original motivating bug that started the GraspVerifier work
- personalrobotics/geodude#177 — sim-magic elimination meta-issue
- personalrobotics/mj_manipulator#96, #97, #99, #101, #102, #107, #108 — the GraspVerifier PR chain that preceded this