### PR TITLE
E-Stop cleanup: persistent abort, CLI logging

### DIFF
--- a/src/geodude/primitives.py
+++ b/src/geodude/primitives.py
@@ -18,6 +18,7 @@ import numpy as np
 import py_trees
 from mj_manipulator.primitives import (
     _arm_preempted,
+    _estop_active,
     _recover,
     _report_pickup_failure,
     _set_hud_action,
@@ -56,9 +57,8 @@ def pickup(
     if verbose is None:
         verbose = robot.config.debug.verbose
 
-    robot.clear_abort()
-    # Don't deactivate teleop — if the operator activated it, respect
-    # their intent. _arm_unavailable skips teleop arms in the loop.
+    if _estop_active(robot):
+        return False
     try:
         return _pickup_inner(robot, target, arm=arm, verbose=verbose)
     except KeyboardInterrupt:
@@ -68,8 +68,6 @@ def pickup(
             _set_hud_action(robot, side, "⊘ interrupted")
         _sync_viewer(robot)
         return False
-    finally:
-        robot.clear_abort()
 
 
 def _pickup_inner(
@@ -134,9 +132,15 @@ def _pickup_inner(
             _sync_viewer(robot)
             return True
         sides_tried.append(side)
-        # Clear abort from this arm's BT run (e.g. drop-detection
-        # abort, teleop preemption) so the other arm gets a chance.
-        robot.clear_abort()
+
+        if robot.is_abort_requested():
+            break
+
+        # Clear per-arm abort (teleop preemption, drop detection)
+        # so the other arm can try. Don't clear the global e-stop.
+        if ctx.ownership is not None:
+            ctx.ownership.clear_abort(side)
+
         # Before trying the other arm, send this arm home
         if i < len(sides) - 1 and not _arm_preempted(robot, side):
             go_home(robot, arm=side)
@@ -175,7 +179,8 @@ def place(
     if verbose is None:
         verbose = robot.config.debug.verbose
 
-    robot.clear_abort()
+    if _estop_active(robot):
+        return False
     try:
         return _place_inner(robot, destination, arm=arm, verbose=verbose)
     except KeyboardInterrupt:
@@ -184,8 +189,6 @@ def place(
         _set_hud_action(robot, arm, "⊘ interrupted")
         _sync_viewer(robot)
         return False
-    finally:
-        robot.clear_abort()
 
 
 def _place_inner(
@@ -246,15 +249,14 @@ def go_home(robot: Geodude, *, arm: str | None = None, verbose: bool | None = No
     if verbose is None:
         verbose = robot.config.debug.verbose
 
-    robot.clear_abort()
+    if _estop_active(robot):
+        return False
     try:
         return _go_home_inner(robot, ctx, arm=arm, verbose=verbose)
     except KeyboardInterrupt:
         robot.request_abort()
         logger.warning("go_home interrupted by user")
         return False
-    finally:
-        robot.clear_abort()
 
 
 def _go_home_inner(

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -346,7 +346,7 @@ class Geodude:
     def clear_abort(self) -> None:
         """Clear the abort flag (call before starting a new operation)."""
         if self._abort_event.is_set():
-            logger.info("✓ E-Stop cleared — resuming")
+            logger.warning("✓ E-Stop cleared — resuming")
         if self._context is not None and self._context.ownership is not None:
             self._context.ownership.clear_all()
         self._abort_event.clear()

--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -337,12 +337,16 @@ class Geodude:
         When an ownership registry is available (tick-driven mode), aborts
         all arms via per-arm flags. Falls back to global event otherwise.
         """
+        if not self._abort_event.is_set():
+            logger.warning("⛔ E-Stop activated — all execution halted")
         if self._context is not None and self._context.ownership is not None:
             self._context.ownership.abort_all()
         self._abort_event.set()
 
     def clear_abort(self) -> None:
         """Clear the abort flag (call before starting a new operation)."""
+        if self._abort_event.is_set():
+            logger.info("✓ E-Stop cleared — resuming")
         if self._context is not None and self._context.ownership is not None:
             self._context.ownership.clear_all()
         self._abort_event.clear()


### PR DESCRIPTION
## Summary
- Remove `robot.clear_abort()` from primitive entry/finally blocks — E-Stop now persists until the user explicitly clicks Resume
- Replace between-arm `robot.clear_abort()` with per-arm `ctx.ownership.clear_abort(side)` so global E-Stop is respected while still allowing the second arm to try
- Log E-Stop activation and clearing in `request_abort()`/`clear_abort()`
- Use `_estop_active()` check at primitive entry — logs "E-Stop is active — command ignored"

Requires personalrobotics/mj_manipulator#119

## Test plan
- [ ] Press E-Stop in browser, try `robot.pickup()` in CLI — should see warning and return False
- [ ] Click Resume, try again — should work
- [ ] Run `sort_all()`, press E-Stop mid-run — should halt and stay halted
- [ ] Verify per-arm abort still allows second arm to try when first arm fails (not E-Stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)