### PR TITLE
Plan arm motion in forked env instead of teleporting base

### DIFF
--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -733,36 +733,42 @@ class Geodude:
     ) -> PlanResult | None:
         """Plan with a single arm at a specific base height.
 
-        Teleports the base for planning (so IK/RRT sees the correct
-        workspace), then restores it. The base trajectory is included
-        in the PlanResult so ctx.execute() moves the base properly
-        through physics/kinematics.
+        Plans in a forked environment with the base at the target height,
+        so live state is never mutated. The base trajectory is included
+        in the PlanResult so ctx.execute() moves the base properly.
         """
         base = self._get_base_for_arm(arm)
-        original_height = None
         base_traj = None
 
-        # Plan base trajectory and teleport for arm planning
+        # Plan base trajectory on live state (read-only collision query)
         if height is not None and base is not None:
             current_height = base.get_height()
             if abs(current_height - height) > 0.001:
                 base_traj = base.plan_to(height, check_collisions=True)
                 if base_traj is None:
                     return None  # path blocked by collision
-                original_height = current_height
-                base.set_height(height)  # teleport for arm planning
 
-        # Resolve timeout from config if not specified
+        # Fork env and set base to target height for arm planning.
+        # No live state mutation — the fork is discarded after planning.
+        planning_env = self._env.fork()
+        if height is not None and base is not None:
+            planning_env.data.qpos[base._qpos_idx] = height
+            mujoco.mj_forward(planning_env.model, planning_env.data)
+
         if timeout is None:
             timeout = self.config.planning.timeout
 
-        # Plan arm motion (with base at target height)
+        # Plan arm in the fork (base at target height, everything else live)
         try:
+            config = arm._make_planner_config(timeout, None)
+            planner = arm.create_planner(config, planning_env=planning_env)
+            start = arm.get_joint_positions()
+
             if goal_tsrs is not None:
                 tsrs = goal_tsrs if isinstance(goal_tsrs, list) else [goal_tsrs]
-                path = arm.plan_to_tsrs(tsrs, timeout=timeout, seed=seed)
+                path = planner.plan(start=start, goal_tsrs=tsrs, seed=seed)
             elif pose is not None:
-                path = arm.plan_to_pose(pose, timeout=timeout, seed=seed)
+                path = planner.plan(start=start, goal_tsrs=[arm._make_pose_tsr(pose)], seed=seed)
             else:
                 raise ValueError("Must provide goal_tsrs or pose")
         except Exception as e:
@@ -770,14 +776,7 @@ class Geodude:
             path = None
 
         if path is None:
-            # Restore base height on failure
-            if original_height is not None:
-                base.set_height(original_height)
             return None
-
-        # Restore base — execution will move it properly
-        if original_height is not None:
-            base.set_height(original_height)
 
         arm_traj = arm.retime(path)
 

--- a/tests/test_fork_planning.py
+++ b/tests/test_fork_planning.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for fork-based planning in _plan_single.
+
+Verifies that planning at different base heights doesn't mutate
+live state (data.qpos, data.xpos).
+"""
+
+import mujoco
+import numpy as np
+
+from geodude.robot import Geodude
+
+
+class TestForkPlanning:
+    """Verify _plan_single plans in a fork without mutating live state."""
+
+    def test_plan_single_does_not_mutate_base_qpos(self):
+        """Base qpos in live data should be unchanged after _plan_single."""
+        robot = Geodude()
+        mujoco.mj_forward(robot.model, robot.data)
+
+        arm = robot._right_arm
+        base = robot._get_base_for_arm(arm)
+        assert base is not None
+
+        # Set base to a known height and snapshot live state
+        base.set_height(0.25)
+        original_qpos = robot.data.qpos.copy()
+
+        # Plan at a different height
+        robot._plan_single(
+            arm,
+            height=0.1,
+            pose=arm.get_ee_pose(),
+        )
+
+        # Live qpos must be unchanged
+        np.testing.assert_array_equal(
+            robot.data.qpos,
+            original_qpos,
+            err_msg="Live qpos was mutated during planning",
+        )
+
+    def test_plan_single_does_not_mutate_xpos(self):
+        """Body xpos in live data should be unchanged after _plan_single."""
+        robot = Geodude()
+        mujoco.mj_forward(robot.model, robot.data)
+
+        arm = robot._right_arm
+        base = robot._get_base_for_arm(arm)
+        assert base is not None
+
+        base.set_height(0.25)
+        original_xpos = robot.data.xpos.copy()
+
+        robot._plan_single(
+            arm,
+            height=0.4,
+            pose=arm.get_ee_pose(),
+        )
+
+        np.testing.assert_array_equal(
+            robot.data.xpos,
+            original_xpos,
+            err_msg="Live xpos was mutated during planning",
+        )
+
+    def test_plan_single_no_height_change_skips_fork_mutation(self):
+        """When height matches current, no fork mutation needed."""
+        robot = Geodude()
+        mujoco.mj_forward(robot.model, robot.data)
+
+        arm = robot._right_arm
+        base = robot._get_base_for_arm(arm)
+        base.set_height(0.25)
+        original_qpos = robot.data.qpos.copy()
+
+        # Plan at the same height — should skip base mutation in fork
+        robot._plan_single(
+            arm,
+            height=0.25,
+            pose=arm.get_ee_pose(),
+        )
+
+        np.testing.assert_array_equal(
+            robot.data.qpos,
+            original_qpos,
+        )
+
+    def test_plan_single_none_height(self):
+        """Planning with height=None should not touch base at all."""
+        robot = Geodude()
+        mujoco.mj_forward(robot.model, robot.data)
+
+        arm = robot._right_arm
+        base = robot._get_base_for_arm(arm)
+        base.set_height(0.25)
+        original_qpos = robot.data.qpos.copy()
+
+        robot._plan_single(
+            arm,
+            height=None,
+            pose=arm.get_ee_pose(),
+        )
+
+        np.testing.assert_array_equal(
+            robot.data.qpos,
+            original_qpos,
+        )


### PR DESCRIPTION
## Summary
- `_plan_single` now forks the environment, sets the base height in the fork, and plans the arm against that fork
- Live state is never mutated during planning — eliminates the teleport-and-restore pattern
- On hardware, this avoids corrupting the kinematic twin (race with 125Hz encoder updates)
- Uses `Arm.create_planner(planning_env=fork)` from personalrobotics/mj_manipulator#120

Fixes #176

## Test plan
- [ ] All 136 existing tests pass
- [ ] Recycling demo: `sort_all()` works identically (plans at multiple base heights)
- [ ] No `set_height` calls remain in `_plan_single`

🤖 Generated with [Claude Code](https://claude.com/claude-code)