### PR TITLE
Apply fix_robotiq_grip_force to both 2F-140s (fixes #189)

### DIFF
--- a/src/geodude/robot.py
+++ b/src/geodude/robot.py
@@ -389,6 +389,20 @@ class Geodude:
             joint_limits=joint_limits,
         )
 
+        # Rewrite the Robotiq actuator for constant grip force. The
+        # geodude_assets 2F-140 ships with the menagerie position-
+        # actuator bug: force couples to tendon length so grip → 0 at
+        # full close, and a forcerange=[-5, 5] clamp caps peak force at
+        # ~90 N (low end of the real 20–235 N Robotiq spec). The 2F-140
+        # hides the bug in practice because its large pads provide
+        # enough contact area to hold typical objects, but as soon as
+        # we grasp something smaller or slipperier the force-to-zero
+        # behaviour bites. See docs in mj_manipulator/docs/grippers.md
+        # §2 and mj_manipulator#129/geodude#189.
+        from mj_manipulator.grippers.robotiq import fix_robotiq_grip_force
+
+        fix_robotiq_grip_force(self.model, prefix=spec.gripper_prefix)
+
         # Create Robotiq gripper
         gripper = RobotiqGripper(
             self.model,


### PR DESCRIPTION
## Summary

Fixes #189. Applies personalrobotics/mj_manipulator#128's \`fix_robotiq_grip_force\` helper to both left and right 2F-140 actuators, eliminating the shared menagerie position-actuator bug:

\`\`\`
force = 0.3137 * ctrl + 0 + (-100) * length + (-10) * vel
\`\`\`

At \`ctrl=255\` and \`length=0.8\` (fully closed), \`force = 80 − 80 = 0\`. If an object slips through the jaws the gripper relaxes instead of re-closing. \`forcerange = "-5 5"\` also clamps peak tendon force at 5 N (~90 N pad force on the 2F-140, low end of the real 20–235 N spec).

## Why this was latent

The 2F-140 doesn't drop objects in practice because its pads are ~10× larger than the 2F-85's (65×27 mm vs 22×8 mm) — there's enough friction against typical cylindrical objects even at the reduced force. The bug only materializes for:

- Objects thin enough to pass between the pads (triggering the force-to-zero at full close).
- Objects slippery enough that the clamped 5 N tendon isn't sufficient.
- Empty-close states (e.g., a picked-up can slips mid-transport) where we want re-close force > 0.

## Change

One call in \`Geodude._create_arm\`, right before the \`RobotiqGripper\` instantiation:

\`\`\`python
from mj_manipulator.grippers.robotiq import fix_robotiq_grip_force
fix_robotiq_grip_force(self.model, prefix=spec.gripper_prefix)
\`\`\`

\`_create_arm\` runs once per arm (left/right), so both actuators get rewritten.

## Verification

- Both \`left_ur5e/gripper/fingers_actuator\` and \`right_ur5e/gripper/fingers_actuator\` after construction have \`bias[1]=0\` (no length coupling), \`bias[0]=-15\`, \`gain[0]≈0.117647\`, \`forcerange=[-18, 18]\` — the canonical post-fix values.
- 140 pytests pass.
- \`ruff check\` / \`ruff format --check\` clean.
- Recycling demo unchanged in practice: slightly firmer grip (195 N vs 90 N pad force) but same behaviour on the can workload.

## Risk

Low. The only observable change is ~2× firmer grip; rigid cans in sim don't care. If for some reason the old 5 N clamp was deliberate (it wasn't — it was menagerie default), we can tune \`target_tendon_force\` down.

Fixes #189.